### PR TITLE
docs: add skeleton structure for the handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# handbook
-Thoth Tech Employee Handbook
+# Thoth Tech Handbook
+
+This is where we'll try to share about Thoth Tech, the company, our values, our culture and our processes.
+It's a central guide to understand more about what we believe in and how we run the company. As part of
+our value of being transparent, the handbook is open to the world and we welcome feedback. Please create
+a pull request to suggest improvements or add clarifications. Please use issues to ask questions.
+
+## Sections
+
+- Company
+  - Mission
+  - Values
+  - How do we work
+  - Organisational structure
+- Processes
+  - Developer Operations
+  - Quality Assurance
+  - Documentation
+- Roles
+  - Leadership
+  - Delivery Lead
+  - Group Lead
+  - Engineer
+- People Operations
+  - Recruiting
+  - Onboarding
+    - Organisational
+    - Technical
+    - Social
+  - Learning & Development
+- Tools

--- a/README.md
+++ b/README.md
@@ -27,5 +27,8 @@ a pull request to suggest improvements or add clarifications. Please use issues 
     - Organisational
     - Technical
     - Social
+  - Offboarding
+    - Handover
+    - Exit Survey
   - Learning & Development
 - Tools


### PR DESCRIPTION
Propose a skeleton structure for the company handbook. We can start creating individual markdowns for each of the sections and link them back to the main README page.