### PR TITLE
docs: add roles and introduction talking points

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ a pull request to suggest improvements or add clarifications. Please use issues 
   - [Charter](docs/company/charter.md)
   - [Roles](docs/company/roles.md)
   - Structure
+- Leadership
+  - [Meetings](docs/leadership/meetings.md)
 - Processes
   - Developer Operations
   - Quality Assurance

--- a/README.md
+++ b/README.md
@@ -9,16 +9,12 @@ a pull request to suggest improvements or add clarifications. Please use issues 
 
 - Company
   - [Charter](docs/company/charter.md)
+  - [Roles](docs/company/roles.md)
   - Structure
 - Processes
   - Developer Operations
   - Quality Assurance
   - Documentation
-- Roles
-  - Leadership
-  - Delivery Lead
-  - Group Lead
-  - Engineer
 - People Operations
   - Recruiting
   - [Onboarding](docs/peopleops/onboarding/onboarding-process.md)

--- a/docs/company/roles.md
+++ b/docs/company/roles.md
@@ -3,53 +3,24 @@
 ## Delivery Lead
 
 - Communicate/collaborate effectively
-- Empathy for people
-- Interpersonal savvy
+- Have empathy for people
+- Be interpersonal savvy
 - What sort of leader would you like to work with?
 - Leadership skills looking for
-- Not too autocratic, not democratic
-- Strong with drive the solution, drive towards objective
+- Balance autocratic and democratic
+- Strong drive towards objectives and bias for action
 - How to talk to people
-- Collaborative leaders
-- Transparency & accountability - visualisation of objectives
-- Communication of what we are doing, and what our plans are, and what we need
-- Stakeholder management - translating high level to low level and vice versa to communicate progress
-- Risk and issues management
+- Be a collaborator
+- Be transparent and accountable - visualisation of objectives
+- Communicate of what we are doing, what our plans are, and what we need
+- Owen stakeholder management - translating high level to low level and vice versa to communicate progress
+- Own risk and issues management.
 
 ## Product Lead
 
-All of the above but with the delivery leads of your product
+All of the above but with the delivery leads of your product.
 
-- What are blockers? What are the opportunities?
-- Direction of product?
-- Supporting the delivery leads where needed
-
-## Onboarding leads
-
-- Introductions
-- Do you think anything should be added to the lead descriptions?
-- Miro Access - Trello Access etc.
-- Existing documents and resources run through, old PRs etc
-- What should our leadership cadence be? Stand ups Retros?
-- Roles
-- Support
-- Thinking about what your goals as leaders are - what skills can we help you develop?
-- Going through the projects from what we know
-- Leadership skills matrix & availability form
-
-## Leads onboarding team members
-
-- Get to know your team
-- Book your first meeting
-- Set up a project team channel
-- Team work log set up
-- Have a look at your team members from the onboarding manual document - this will give you a bit of a sense of the roles we had in mind for them
-- Channel file organisation set up
-- Get everyone to fill out the teams skill and availability matrix
-- Decide on a team cadence - stand ups, retros
-- Decide on how meetings will run - meeting minutes, meeting agendas etc?
-- How will you collaborate? - Miro? Trello Board?
-- Discuss what is needed - upskilling, scoping - what do you need to plan your project?
-- Discuss area alignments for your team - the thing they want to drive eg. Tech, QA, Docs, Data - ideally a balance
-- Information about QA Process to come to talk about in your team meetings
-- Discussion around Ontrack Tasks - ensuring everyone is aligned
+- Proactively identify blockers and opportunities.
+- Drive the product in the right direction.
+- Support the delivery leads where needed.
+- Make thoughtful decisions motivated by data and research.

--- a/docs/company/roles.md
+++ b/docs/company/roles.md
@@ -1,0 +1,55 @@
+# Roles
+
+## Delivery Lead
+
+- Communicate/collaborate effectively
+- Empathy for people
+- Interpersonal savvy
+- What sort of leader would you like to work with?
+- Leadership skills looking for
+- Not too autocratic, not democratic
+- Strong with drive the solution, drive towards objective
+- How to talk to people
+- Collaborative leaders
+- Transparency & accountability - visualisation of objectives
+- Communication of what we are doing, and what our plans are, and what we need
+- Stakeholder management - translating high level to low level and vice versa to communicate progress
+- Risk and issues management
+
+## Product Lead
+
+All of the above but with the delivery leads of your product
+
+- What are blockers? What are the opportunities?
+- Direction of product?
+- Supporting the delivery leads where needed
+
+## Onboarding leads
+
+- Introductions
+- Do you think anything should be added to the lead descriptions?
+- Miro Access - Trello Access etc.
+- Existing documents and resources run through, old PRs etc
+- What should our leadership cadence be? Stand ups Retros?
+- Roles
+- Support
+- Thinking about what your goals as leaders are - what skills can we help you develop?
+- Going through the projects from what we know
+- Leadership skills matrix & availability form
+
+## Leads onboarding team members
+
+- Get to know your team
+- Book your first meeting
+- Set up a project team channel
+- Team work log set up
+- Have a look at your team members from the onboarding manual document - this will give you a bit of a sense of the roles we had in mind for them
+- Channel file organisation set up
+- Get everyone to fill out the teams skill and availability matrix
+- Decide on a team cadence - stand ups, retros
+- Decide on how meetings will run - meeting minutes, meeting agendas etc?
+- How will you collaborate? - Miro? Trello Board?
+- Discuss what is needed - upskilling, scoping - what do you need to plan your project?
+- Discuss area alignments for your team - the thing they want to drive eg. Tech, QA, Docs, Data - ideally a balance
+- Information about QA Process to come to talk about in your team meetings
+- Discussion around Ontrack Tasks - ensuring everyone is aligned

--- a/docs/leadership/meetings.md
+++ b/docs/leadership/meetings.md
@@ -1,0 +1,29 @@
+# Meetings
+
+## Welcome leads
+
+This meeting gives senior leadership team, product and delivery leads an
+opportunity to:
+
+- Get to know each other and build rapport
+- Provide an opportunity to ask questions
+- Clarify their understanding of company or functional objectives
+
+### Conducting welcome leads meetings
+
+1. Introduction.
+1. Do you think anything should be added to the Lead descriptions?
+1. Please confirm that you have access to tools that allow to do your job (Miro,
+   Trello, GitHub, etc.)
+1. Run through existing documents and resources, old Pull Request, etc.
+1. What should our leadership cadence be? How often do your teams do stand ups,
+   and retros?
+1. Walk through delivery and product lead [roles](../company/roles.md).
+1. Support structure.
+1. Think about what your goals as leaders are - what skills can we help you develop?
+1. Go through the projects from what we know.
+1. Remind to fill in the Leadership skills matrix & availability form.
+
+If time permits, go through the role-specific
+[onboarding process](../peopleops/onboarding/onboarding-process.md) for delivery and
+products lead clarify any concerns.

--- a/docs/peopleops/onboarding/onboarding-process.md
+++ b/docs/peopleops/onboarding/onboarding-process.md
@@ -59,3 +59,24 @@ meeting using Schedule Assistant in the Outlook calendar. Be sure to introduce y
 - [ ] Coffee chat with \_\_
 - [ ] Coffee chat with \_\_
 - [ ] Coffee chat with \_\_
+
+## Role-specific Tasks
+
+### Delivery & Product Lead
+
+- [ ] Get to know your team. Have a look at your team members from the
+      onboarding manual document - this will give you a sense of the
+      roles we had in mind for them.
+- [ ] Book your first meeting.
+- [ ] Set up a project team channel on Microsoft Team.
+- [ ] Set up team work log to record activities of team members.
+- [ ] Set up file organisation on Microsoft Team/SharePoint.
+- [ ] Get everyone to fill out the teams skill and availability matrix.
+- [ ] Decide on a team cadence - stand ups, retros, etc.
+- [ ] Decide on how meetings will run - meeting minutes, meeting agendas, etc.
+- [ ] How will you collaborate? - Miro? Trello Board?
+- [ ] Discuss what activities are needed - upskilling, scoping, etc. What do you need to plan your project?
+- [ ] Discuss area alignments for your team - the thing they want to drive (e.g.
+      Tech, QA, Docs, Data - ideally a balance).
+- [ ] Information about QA Process to come to talk about in your team meetings.
+- [ ] Discussion around project tasks - ensuring everyone is aligned.


### PR DESCRIPTION
- Add `Welcome leads meeting` section with talking points
- Add defined roles and expectation for delivery and product leads
- Add role-specific onboarding for delivery and product leads