### PR TITLE
docs: add teams and contact information

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ a pull request to suggest improvements or add clarifications. Please use issues 
   - Structure
 - Leadership
   - [Meetings](docs/leadership/meetings.md)
+- [Teams](docs/teams/teams.md)
 - Processes
   - Developer Operations
   - Quality Assurance

--- a/docs/teams/teams.md
+++ b/docs/teams/teams.md
@@ -118,16 +118,18 @@ Product Lead: Yash Kondlekar
 
 #### Python Compatibility
 
+- Trello Board: [Python Compatibility](https://trello.com/b/cZXHjIv0/python-compatability)
 - Team Member: Norbert Pop, Jack Sievers, Ben Thomas, Liu Sicheng
 
 #### Language Extensions
 
+- Trello Board: [Language Extensions](https://trello.com/b/xIVeBYwU/language-extensions)
 - Team Member: Dylan Medlin, Du Jingze, Timothy Wilbert
 
 ### Applications
 
 - Teams Channel: [Applications Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Applications%20Team?threadId=19:1a52251788de42edbda8153f1913bd90@thread.tacv2&ctx=channel)
-- Trello Board: TBD
+- Trello Board: [Acarde Team](https://trello.com/b/cnMs1BW6/arcade-team)
 - Delivery Lead: Nick Agiazis
 
 #### Arcade Machine
@@ -136,12 +138,12 @@ Product Lead: Yash Kondlekar
 
 #### Build a Cool Game
 
-Team Member: Lily Lan, Morgaine Barter, Bella Chhour
+- Team Member: Lily Lan, Morgaine Barter, Bella Chhour
 
 ### Modules
 
 - Teams Channel: [SplashKit Modules](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/SplashKit%20Modules?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:3abb0a52353b436db927e16d3c152903@thread.tacv2&ctx=channel)
-- Trello Board: TBD
+- Trello Board: [Modules](https://trello.com/b/SKqf30oS/modules)
 - Delivery Lead: Alex Hocking
 
 #### Physics

--- a/docs/teams/teams.md
+++ b/docs/teams/teams.md
@@ -1,0 +1,146 @@
+# Teams
+
+## Technical Learning group
+
+Area Lead: Liz Lynch
+
+## Quality Analysis group
+
+Area Lead: Katrina Steen
+
+## People & Documentation group
+
+Area Lead: Talia Zidar
+
+## Data Science & Product Analytics group
+
+Area Lead: Tan Le
+
+## OnTrack group
+
+Product Lead: Jordan Trainor
+
+### Front-end Migration
+
+- Teams Channel: TBD
+- Delivery Lead: David Kwiatkowski, Jesse Hancock
+- Team Member (pair):
+  - Mitchell Burcheri, Zhao Yiqing
+  - Saleh Alharbi, Anthony Papoutsis
+  - Ma Junhua, Cai Oscar
+  - Perry Rose, Chen Renhao
+  - Zheng Jiahao, Huang Yongqi
+  - Adbullah Algamdi, Grady Ransay
+  - Ishrat Jahan, Ricardo Ingles
+  - Leo Luong, Ni Leo
+
+### Deployment
+
+- Teams Channel: TBD
+- Delivery Lead: TBD
+
+#### Google Cloud
+
+Team Member: Joyce Cruz, Sultan Albishri
+
+#### Pipeline Build
+
+Team Member: Matt Perkins, Lachlan Cayzer
+
+#### Enhance Authentication
+
+Team Member: Nathan Sukamto, Sarah Dyson, Xue Jing, Linden Hutchinson
+
+### Jupyter Notebook Support
+
+- Teams Channel: [Jupyter Notebook Support Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/General?threadId=19:TfS2kJmJ0HXihVO4_9pXuxrzAN_4em5uQgIvQByzhWQ1@thread.tacv2&ctx=channel)
+- Delivery Lead: Matt Clark
+- Team Member: Jordan Litsas, Ethan Keirs, Lachlan Foy, Chetan Nagar
+
+### Voice Verification
+
+- Teams Channel: [Voice Verification - OnTrack](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3Aea448ec4e26449a5b74e0d6dc9be71f4%40thread.tacv2%2FVoice%2520Verification%2520-%2520OnTrack%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=fd1ba64e-fdab-4b8f-a6a9-ab5259fce16c&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Delivery Lead: Shaine Christmas
+- Team Member: Devin Jayasinghe, Yanjun Chen, Gao Yujun, Ha Nguyen, Daniel Le
+
+### Documentation
+
+- Teams Channel: [OnTrack Documentation](https://teams.microsoft.com/l/channel/19%3arhz4yutH2rF0sJU-xbcqAIS-tZ59n3j2c5LMzqDdicA1%40thread.tacv2/General?groupId=215e9f4e-95e6-4a1a-84b7-489f22d4ecae&tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6)
+- Delivery Lead: James Micallef
+- Team Member: Parth Aneja, Manisha Jyoti, MD Fahim Mizi, Shivam Singh, Kosta Constantinou
+
+## DreamBig
+
+Product Lead: Abigail Howe
+
+### DreamBig Prototype
+
+- Teams Channel: [DreamBig Prototype Team](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3A71cf013320fb430db1e7427d9d7d61ad%40thread.tacv2%2FDreamBig%2520Prototype%2520Team%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=435cbc9f-c2e5-4942-8397-2a0214d3af75&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Delivery Lead: Neha Makineni
+- Team Member: Li Harry, Chen Guanyu, Munatsi Matipano, Zac Brydon, Harrison Allwood, Lei Feng, George Gkoumas
+
+### Internal Systems
+
+- Teams Channel: [Internal Systems](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3A8778e877fdca4e899c42d52b1b1ead32%40thread.tacv2%2FInternal%2520Systems%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=791c774f-c1a9-48b0-8f11-19bad44f738f&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Delivery Lead: Matthew Fletcher
+- Team Member: Areeb Jjaz, Tushar, Manveen Bhullar
+
+## SplashKit
+
+Product Lead: Yash Kondlekar
+
+### Operations
+
+- Teams Channel: [SplashKit Operations Team](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3A845469c493864784b3de109e2da8060b%40thread.tacv2%2FSplashKit%2520Operations%2520Team%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=a95fe626-299a-4ce2-8f18-a7695635a548&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Delivery Lead: Aiden Molluso
+
+#### Migrate Arcana to SplashKit
+
+- Team Member: Devesh Juggiah, Ray Guo
+
+#### Distribution Channels
+
+- Team Member: Lachlan Morgan, Trent Mizzi, Richard Denton
+
+### Extensions
+
+- Teams Channel: TBD
+- Delivery Lead: Allan Farrell
+
+#### Python Compatibility
+
+- Team Member: Norbert Pop, Jack Sievers, Ben Thomas, Liu Sicheng
+
+#### Language Extensions
+
+- Team Member: Dylan Medlin, Du Jingze, Timothy Wilbert
+
+### Applications
+
+- Teams Channel: [Applications Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Applications%20Team?threadId=19:1a52251788de42edbda8153f1913bd90@thread.tacv2&ctx=channel)
+- Delivery Lead: Nick Agiazis
+
+#### Arcade Machine
+
+- Team Member: Nguyen Pham, Riley Dellios, Anthony George, Sarah Gosling
+
+#### Build a Cool Game
+
+Team Member: Lily Lan, Morgaine Barter, Bella Chhour
+
+### Modules
+
+- Teams Channel: [SplashKit Modules](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/SplashKit%20Modules?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:3abb0a52353b436db927e16d3c152903@thread.tacv2&ctx=channel)
+- Delivery Lead: Alex Hocking
+
+#### Physics
+
+- Team Member: Daniel Haysham, Kanna Srilakshmanan
+
+#### Machine Learning
+
+- Team Member: Harry Dentry, Ricky Dodd
+
+#### Data Analytics
+
+- Team Member: Ryan Lawrence, Timothy Moore, Tao Kai

--- a/docs/teams/teams.md
+++ b/docs/teams/teams.md
@@ -22,7 +22,7 @@ Product Lead: Jordan Trainor
 
 ### Front-end Migration
 
-- Teams Channel: TBD
+- Teams Channel: [Front End Migration](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Front%20End%20Migration?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:40cc53f7f52d42cd8d15bddad593aa01@thread.tacv2&ctx=channel)
 - Trello Board: [Front-end Migration](https://trello.com/b/pFPgCaIo/front-end-migration)
 - Delivery Lead: David Kwiatkowski, Jesse Hancock
 - Team Member (pair):
@@ -37,9 +37,9 @@ Product Lead: Jordan Trainor
 
 ### Deployment
 
-- Teams Channel: TBD
+- Teams Channel: [Deployment](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Deployment?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:42df0a88caed442a867bc8c41c25416d@thread.tacv2&ctx=channel)
 - Trello Board: [Deployment](https://trello.com/b/dI1yx9A1/deployment)
-- Delivery Lead: TBD
+- Delivery Lead: Jordan Trainor (Interim)
 
 #### Google Cloud
 
@@ -62,7 +62,7 @@ Team Member: Nathan Sukamto, Sarah Dyson, Xue Jing, Linden Hutchinson
 
 ### Voice Verification
 
-- Teams Channel: [Voice Verification - OnTrack](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3Aea448ec4e26449a5b74e0d6dc9be71f4%40thread.tacv2%2FVoice%2520Verification%2520-%2520OnTrack%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=fd1ba64e-fdab-4b8f-a6a9-ab5259fce16c&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Teams Channel: [Voice Verification - OnTrack](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Voice%20Verification%20-%20OnTrack?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:ea448ec4e26449a5b74e0d6dc9be71f4@thread.tacv2&ctx=channel)
 - Trello Board: [Voice Verification](https://trello.com/b/lkRdh1Fp/voice-verification)
 - Delivery Lead: Shaine Christmas
 - Team Member: Devin Jayasinghe, Yanjun Chen, Gao Yujun, Ha Nguyen, Daniel Le
@@ -80,14 +80,14 @@ Product Lead: Abigail Howe
 
 ### DreamBig Prototype
 
-- Teams Channel: [DreamBig Prototype Team](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3A71cf013320fb430db1e7427d9d7d61ad%40thread.tacv2%2FDreamBig%2520Prototype%2520Team%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=435cbc9f-c2e5-4942-8397-2a0214d3af75&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Teams Channel: [DreamBig Prototype Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/DreamBig%20Prototype%20Team?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:71cf013320fb430db1e7427d9d7d61ad@thread.tacv2&ctx=channel)
 - Trello Board: [DreamBig](https://trello.com/b/5hGRqxJO/dreambig)
 - Delivery Lead: Neha Makineni
 - Team Member: Li Harry, Chen Guanyu, Munatsi Matipano, Zac Brydon, Harrison Allwood, Lei Feng, George Gkoumas
 
 ### Internal Systems
 
-- Teams Channel: [Internal Systems](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3A8778e877fdca4e899c42d52b1b1ead32%40thread.tacv2%2FInternal%2520Systems%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=791c774f-c1a9-48b0-8f11-19bad44f738f&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Teams Channel: [Internal Systems](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Internal%20Systems?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:8778e877fdca4e899c42d52b1b1ead32@thread.tacv2&ctx=channel)
 - Trello Board: [Internal Systems](https://trello.com/b/Y3chllnR/internal-systems)
 - Delivery Lead: Matthew Fletcher
 - Team Member: Areeb Jjaz, Tushar, Manveen Bhullar
@@ -98,12 +98,13 @@ Product Lead: Yash Kondlekar
 
 ### Operations
 
-- Teams Channel: [SplashKit Operations Team](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3A845469c493864784b3de109e2da8060b%40thread.tacv2%2FSplashKit%2520Operations%2520Team%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=a95fe626-299a-4ce2-8f18-a7695635a548&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Teams Channel: [SplashKit Operations Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/SplashKit%20Operations%20Team?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:845469c493864784b3de109e2da8060b@thread.tacv2&ctx=channel)
 - Trello Board: TBD
 - Delivery Lead: Aiden Molluso
 
 #### Migrate Arcana to SplashKit
 
+- Trello Board: [Migrate Arcana to SplashKit](https://trello.com/b/ci4vjDkG/migrate-arcana-to-splashkit)
 - Team Member: Devesh Juggiah, Ray Guo
 
 #### Distribution Channels
@@ -113,7 +114,6 @@ Product Lead: Yash Kondlekar
 ### Extensions
 
 - Teams Channel: TBD
-- Trello Board: TBD
 - Delivery Lead: Allan Farrell
 
 #### Python Compatibility

--- a/docs/teams/teams.md
+++ b/docs/teams/teams.md
@@ -23,6 +23,7 @@ Product Lead: Jordan Trainor
 ### Front-end Migration
 
 - Teams Channel: TBD
+- Trello Board: [Front-end Migration](https://trello.com/b/pFPgCaIo/front-end-migration)
 - Delivery Lead: David Kwiatkowski, Jesse Hancock
 - Team Member (pair):
   - Mitchell Burcheri, Zhao Yiqing
@@ -37,6 +38,7 @@ Product Lead: Jordan Trainor
 ### Deployment
 
 - Teams Channel: TBD
+- Trello Board: [Deployment](https://trello.com/b/dI1yx9A1/deployment)
 - Delivery Lead: TBD
 
 #### Google Cloud
@@ -54,18 +56,21 @@ Team Member: Nathan Sukamto, Sarah Dyson, Xue Jing, Linden Hutchinson
 ### Jupyter Notebook Support
 
 - Teams Channel: [Jupyter Notebook Support Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/General?threadId=19:TfS2kJmJ0HXihVO4_9pXuxrzAN_4em5uQgIvQByzhWQ1@thread.tacv2&ctx=channel)
+- Trello Board: [Jupyter Support](https://trello.com/b/3lWJEuDQ/jupyter-sypport)
 - Delivery Lead: Matt Clark
 - Team Member: Jordan Litsas, Ethan Keirs, Lachlan Foy, Chetan Nagar
 
 ### Voice Verification
 
 - Teams Channel: [Voice Verification - OnTrack](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3Aea448ec4e26449a5b74e0d6dc9be71f4%40thread.tacv2%2FVoice%2520Verification%2520-%2520OnTrack%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=fd1ba64e-fdab-4b8f-a6a9-ab5259fce16c&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Trello Board: [Voice Verification](https://trello.com/b/lkRdh1Fp/voice-verification)
 - Delivery Lead: Shaine Christmas
 - Team Member: Devin Jayasinghe, Yanjun Chen, Gao Yujun, Ha Nguyen, Daniel Le
 
 ### Documentation
 
 - Teams Channel: [OnTrack Documentation](https://teams.microsoft.com/l/channel/19%3arhz4yutH2rF0sJU-xbcqAIS-tZ59n3j2c5LMzqDdicA1%40thread.tacv2/General?groupId=215e9f4e-95e6-4a1a-84b7-489f22d4ecae&tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6)
+- Trello Board: [Documentation](https://trello.com/b/FHz8evJG/documentation)
 - Delivery Lead: James Micallef
 - Team Member: Parth Aneja, Manisha Jyoti, MD Fahim Mizi, Shivam Singh, Kosta Constantinou
 
@@ -76,12 +81,14 @@ Product Lead: Abigail Howe
 ### DreamBig Prototype
 
 - Teams Channel: [DreamBig Prototype Team](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3A71cf013320fb430db1e7427d9d7d61ad%40thread.tacv2%2FDreamBig%2520Prototype%2520Team%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=435cbc9f-c2e5-4942-8397-2a0214d3af75&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Trello Board: [DreamBig](https://trello.com/b/5hGRqxJO/dreambig)
 - Delivery Lead: Neha Makineni
 - Team Member: Li Harry, Chen Guanyu, Munatsi Matipano, Zac Brydon, Harrison Allwood, Lei Feng, George Gkoumas
 
 ### Internal Systems
 
 - Teams Channel: [Internal Systems](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3A8778e877fdca4e899c42d52b1b1ead32%40thread.tacv2%2FInternal%2520Systems%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=791c774f-c1a9-48b0-8f11-19bad44f738f&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Trello Board: [Internal Systems](https://trello.com/b/Y3chllnR/internal-systems)
 - Delivery Lead: Matthew Fletcher
 - Team Member: Areeb Jjaz, Tushar, Manveen Bhullar
 
@@ -92,6 +99,7 @@ Product Lead: Yash Kondlekar
 ### Operations
 
 - Teams Channel: [SplashKit Operations Team](https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fchannel%2F19%3A845469c493864784b3de109e2da8060b%40thread.tacv2%2FSplashKit%2520Operations%2520Team%3FgroupId%3D0e15669c-3f66-49aa-b023-640fe1dda2e0%26tenantId%3Dd02378ec-1688-46d5-8540-1c28b5f470f6&type=channel&deeplinkId=a95fe626-299a-4ce2-8f18-a7695635a548&directDl=true&msLaunch=true&enableMobilePage=true&suppressPrompt=true)
+- Trello Board: TBD
 - Delivery Lead: Aiden Molluso
 
 #### Migrate Arcana to SplashKit
@@ -105,6 +113,7 @@ Product Lead: Yash Kondlekar
 ### Extensions
 
 - Teams Channel: TBD
+- Trello Board: TBD
 - Delivery Lead: Allan Farrell
 
 #### Python Compatibility
@@ -118,6 +127,7 @@ Product Lead: Yash Kondlekar
 ### Applications
 
 - Teams Channel: [Applications Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Applications%20Team?threadId=19:1a52251788de42edbda8153f1913bd90@thread.tacv2&ctx=channel)
+- Trello Board: TBD
 - Delivery Lead: Nick Agiazis
 
 #### Arcade Machine
@@ -131,6 +141,7 @@ Team Member: Lily Lan, Morgaine Barter, Bella Chhour
 ### Modules
 
 - Teams Channel: [SplashKit Modules](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/SplashKit%20Modules?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:3abb0a52353b436db927e16d3c152903@thread.tacv2&ctx=channel)
+- Trello Board: TBD
 - Delivery Lead: Alex Hocking
 
 #### Physics


### PR DESCRIPTION
## What

Add a doc to list all teams

## Why

It is hard to lookup for team members, which teams they are part of as well as important delivery and product information.

## How

This PR adds a new `teams` doc which documents:
- All Thoth Tech teams
- Team members and roles
- Communication channels (MS Teams)
- Delivery tracker (Trello)