### PR TITLE
docs: Added PR template file 

### DIFF
--- a/docs/processes/quality-assurance/templates/pr-template.md
+++ b/docs/processes/quality-assurance/templates/pr-template.md
@@ -32,5 +32,5 @@ _Please describe the tests that you ran to verify your changes. Provide instruct
 - [ ] I have commented my code in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
-- [ ] I have requested a review from  *** on the Pull Request
+- [ ] I have requested a review from NAMES HERE on the Pull Request
 

--- a/docs/processes/quality-assurance/templates/pr-template.md
+++ b/docs/processes/quality-assurance/templates/pr-template.md
@@ -33,4 +33,3 @@ _Please describe the tests that you ran to verify your changes. Provide instruct
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have requested a review from NAMES HERE on the Pull Request
-

--- a/docs/processes/quality-assurance/templates/pr-template.md
+++ b/docs/processes/quality-assurance/templates/pr-template.md
@@ -1,0 +1,36 @@
+_Any italic text should be deleted from the final Pull Request text, including this line_
+
+# Description
+
+_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._
+
+Fixes # (issue)
+
+## Type of change
+
+_Please delete options that are not relevant._
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_
+
+## Testing Checklist:
+
+- [ ] Tested in latest Chrome
+- [ ] Tested in latest Safari
+- [ ] Tested in latest Firefox
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have requested a review from  *** on the Pull Request
+


### PR DESCRIPTION
Added PR template file to be updated based on QA processes and guidelines, and then will be used to automatically fill the open a PR box.