### PR TITLE
Add guides on diagrams and collapse blocks

### DIFF
--- a/docs/learning/training/markdown-guide.md
+++ b/docs/learning/training/markdown-guide.md
@@ -89,11 +89,12 @@ The hidden content is revealed inline. For example, this code:
 
 ```markdown
 <details>
-<summary markdown="span">This is the summary text, click me to expand</summary>
+<summary>This is the summary text, click me to expand</summary>
 
 This is the detailed text.
 
-You can learn more about expected usage of this approach in the [ThothTech markdown guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/markdown-guide.md).
+You can learn more about expected usage of this approach in the
+[ThothTech markdown guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/markdown-guide.md).
 
 </details>
 ```
@@ -101,19 +102,14 @@ You can learn more about expected usage of this approach in the [ThothTech markd
 results in:
 
 <details>
-<summary markdown="span">This is the summary text, click me to expand</summary>
+<summary>This is the summary text, click me to expand</summary>
 
 This is the detailed text.
 
-You can learn more about expected usage of this approach in the [ThothTech markdown guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/markdown-guide.md).
+You can learn more about expected usage of this approach in the
+[ThothTech markdown guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/markdown-guide.md).
 
 </details>
-
-To add markdown in the collapsed heading, be sure to add:
-
-```
-<details markdown="1">
-```
 
 ## Using VS Code to preview Markdown
 

--- a/docs/learning/training/markdown-guide.md
+++ b/docs/learning/training/markdown-guide.md
@@ -94,7 +94,7 @@ The hidden content is revealed inline. For example, this code:
 This is the detailed text.
 
 You can learn more about expected usage of this approach in the
-[ThothTech markdown guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/markdown-guide.md).
+[Thoth Tech markdown guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/markdown-guide.md).
 
 </details>
 ```
@@ -107,7 +107,7 @@ results in:
 This is the detailed text.
 
 You can learn more about expected usage of this approach in the
-[ThothTech markdown guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/markdown-guide.md).
+[Thoth Tech markdown guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/markdown-guide.md).
 
 </details>
 

--- a/docs/learning/training/markdown-guide.md
+++ b/docs/learning/training/markdown-guide.md
@@ -1,20 +1,14 @@
 # Markdown Guide
 
-[What is Markdown?](#what-is-markdown)
-
-[Thoth Tech and Markdown](#thoth-tech-and-markdown)
-
-[Guide to Using Markdown](#guide-to-using-markdown)
-
-[Using VS Code to Preview Markdown](#using-vs-code-to-preview-markdown)
-
-[Markdown Templates](#markdown-templates)
-
----
+- [What is Markdown?](#what-is-markdown)
+- [Thoth Tech and Markdown](#thoth-tech-and-markdown)
+- [Guide to Using Markdown](#guide-to-using-markdown)
+- [Using VS Code to Preview Markdown](#using-vs-code-to-preview-markdown)
+- [Markdown Templates](#markdown-templates)
 
 ## What is Markdown?
 
-Markdown (md) is a markup language, similar to a .txt file, but with basic **in-text** formating
+Markdown (`.md`) is a markup language, similar to a `.txt` file, but with basic **in-text** formating
 elements. Although it can produce similar outputs as a word processor, there are other benefits that Thoth Tech can leverage.
 
 ### Thoth Tech and Markdown
@@ -31,15 +25,13 @@ This decision is based on a number of factors:
 
 Many tools are capable of working in Markdown (**Dillinger and VS Code are good starting points**)
 
----
+## Guide to using Markdown
 
-## Guide to Using Markdown
+### How do I create a Markdown file?
 
-_How do I create a Markdown file?_
+It's simple to specify a file as Markdown. Simply name it with the extension `.md`.
 
-It's simple to specify a file as Markdown. Simply name it with the extension `.md`
-
-_How do I format a Markdown file?_
+### How do I format a Markdown file?
 
 [The Markdown Guide](https://www.markdownguide.org) is an excellent online resource providing at-a-glance formatting examples.
 
@@ -63,28 +55,83 @@ Commonly used formatting options include the following:
 | `---`                                        | <hr>                                       |
 | `[Link Name](https://www.markdownguide.org)` | [Link Name](https://www.markdownguide.org) |
 
----
+### Diagrams
+
+You can generate diagrams and flowcharts from text by using [Mermaid](https://mermaid-js.github.io/mermaid/#/).
+
+The [Mermaid Live Editor](https://mermaid-js.github.io/mermaid-live-editor/) helps you learn Mermaid and debug
+issues in your Mermaid code. Use it to identify and resolve issues in your diagrams.
+
+To generate a diagram or flowchart, write your text inside the mermaid block:
+
+````markdown
+```mermaid
+graph TD
+  A[Dinner]-->B[Tacos]
+  A-->C[Noodles]
+  B-->D[Fulfillment]
+  C-->D
+```
+````
+
+```mermaid
+graph TD
+  A[Dinner]-->B[Tacos]
+  A-->C[Noodles]
+  B-->D[Fulfillment]
+  C-->D
+```
+
+#### Collapse
+
+A collapsed content section is used to hide information until a user chooses to reveal it with a click or tap on the summary text.
+The hidden content is revealed inline. For example, this code:
+
+```markdown
+<details>
+<summary markdown="span">This is the summary text, click me to expand</summary>
+
+This is the detailed text.
+
+You can learn more about expected usage of this approach in the [ThothTech markdown guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/markdown-guide.md).
+
+</details>
+```
+
+results in:
+
+<details>
+<summary markdown="span">This is the summary text, click me to expand</summary>
+
+This is the detailed text.
+
+You can learn more about expected usage of this approach in the [ThothTech markdown guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/markdown-guide.md).
+
+</details>
+
+To add markdown in the collapsed heading, be sure to add:
+
+```
+<details markdown="1">
+```
 
 ## Using VS Code to preview Markdown
 
 VS Code has built in support for previewing Markdown files.
 
-_**Mac Users**_
+### Mac Users
 
 To open your **current tab** in **Markdown preview**, use _shift + command + v_.
 
 To create a **split screen view** (allowing you to edit your Markdown file in one screen while previewing in another, side-by-side), press _command + k_, release the keys, then press _v_.
 
-_**Windows Users**_
+### Windows Users
 
 To open your **current tab** in **Markdown preview**, use _shift + ctrl + v_.
 
 To create a **split screen view** (allowing you to edit your Markdown file in one screen while previewing in another, side-by-side), press _ctrl + k_, release the keys, then press _v_.
 
----
-
 ## Markdown Templates
 
-[Epic Markdown Template](../leadership/epic-template.md)
-
-[Meeting Markdown Template](../leadership/meeting-template.md)
+- [Epic Markdown Template](../leadership/epic-template.md)
+- [Meeting Markdown Template](../leadership/meeting-template.md)


### PR DESCRIPTION
# Description

Add some information on usages of Mermaid diagrams and Collapse blocks in Markdown.

Fixes https://github.com/thoth-tech/handbook/issues/65

## Type of change

- [x] Documentation (update or new)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
