### PR TITLE
fix: use consistent prettier rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,8 @@ _Any italic text should be deleted from the final Pull Request text, including t
 
 # Description
 
-_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._
+_Please include a summary of the change and which issue is fixed. Please also include relevant
+motivation and context. List any dependencies that are required for this change._
 
 Fixes # (issue)
 
@@ -12,12 +13,14 @@ _Please delete options that are not relevant._
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
+      expected)
 - [ ] Documentation (update or new)
 
 # How Has This Been Tested?
 
-_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_
+_Please describe the tests that you ran to verify your changes. Provide instructions so we can
+reproduce. Please also list any relevant details for your test configuration_
 
 ## Testing Checklist:
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "printWidth": 80
+  "printWidth": 100,
+  "proseWrap": "always"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,16 @@
 # Contributing
 
-You can help to improve the Thoth Tech company handbook by sending pull requests
-to this repository. Thank you for your interest and help!
+You can help to improve the Thoth Tech company handbook by sending pull requests to this repository.
+Thank you for your interest and help!
 
-Feel free to make a proposal, we can discuss anything and if we don't agree
-we'll feel free not to merge it and we'll thank you for caring about it. We want
-to create a welcoming environment for everyone who is interested in
-contributing.
+Feel free to make a proposal, we can discuss anything and if we don't agree we'll feel free not to
+merge it and we'll thank you for caring about it. We want to create a welcoming environment for
+everyone who is interested in contributing.
 
 ## Documentation testing
 
-We treat documentation like code. Therefore, we use processes similar to those
-used for code to maintain standards and quality of documentation.
+We treat documentation like code. Therefore, we use processes similar to those used for code to
+maintain standards and quality of documentation.
 
 We have tests:
 
@@ -19,24 +18,22 @@ We have tests:
 
 ### Run tests locally
 
-You can run these tests on your local computer. This has the advantage of
-speeding up the feedback loop. You can know of any problems with the changes in
-your branch without waiting for a CI pipeline to run.
+You can run these tests on your local computer. This has the advantage of speeding up the feedback
+loop. You can know of any problems with the changes in your branch without waiting for a CI pipeline
+to run.
 
 To run the tests locally, it's important to:
 
 - [Install the tools](#installation)
-- Run [linters](#lint-checks) the same way they are run in CI pipelines. It's
-  important to use same configuration we use in CI pipelines, which can be
-  different than the default configuration of the tool.
+- Run [linters](#lint-checks) the same way they are run in CI pipelines. It's important to use same
+  configuration we use in CI pipelines, which can be different than the default configuration of the
+  tool.
 
 ### Local linters
 
-To help adhere to the
-[documentation style guidelines](/docs/documetation/writing-style-guide.md), and
-improve the content added to documentation,
-[install documentation linters](#install-linters) and
-[integrate them with your code editor](#configure-editors).
+To help adhere to the [documentation style guidelines](/docs/documetation/writing-style-guide.md),
+and improve the content added to documentation, [install documentation linters](#install-linters)
+and [integrate them with your code editor](#configure-editors).
 
 At Thoth Tech, we mostly use:
 
@@ -50,14 +47,13 @@ At Thoth Tech, we mostly use:
 
 #### Vale
 
-[Vale](https://docs.errata.ai/vale/about/) is a grammar, style, and word usage
-linter for the English language. Vale's configuration is stored in the
-[`.vale.ini`](https://github.com/thoth-tech/handbook/blob/main/.vale.ini) file
-located in the root directory.
+[Vale](https://docs.errata.ai/vale/about/) is a grammar, style, and word usage linter for the
+English language. Vale's configuration is stored in the
+[`.vale.ini`](https://github.com/thoth-tech/handbook/blob/main/.vale.ini) file located in the root
+directory.
 
-Vale supports creating [custom tests](https://docs.errata.ai/vale/styles) that
-extend any of several types of checks, which we store in the `.vale/thothtech/`
-directory in the documentation directory.
+Vale supports creating [custom tests](https://docs.errata.ai/vale/styles) that extend any of several
+types of checks, which we store in the `.vale/thothtech/` directory in the documentation directory.
 
 ##### Vale result types
 
@@ -75,14 +71,13 @@ we have implemented
 [the Flesch-Kincaid grade level test](https://readable.com/readability/flesch-reading-ease-flesch-kincaid-grade-level/)
 to determine the readability of our documentation.
 
-As a general guideline, the lower the score, the more readable the
-documentation. For example, a page that scores `12` before a set of changes, and
-`9` after, indicates an iterative improvement to readability. The score is not
-an exact science, but is meant to help indicate the general complexity level of
-the page.
+As a general guideline, the lower the score, the more readable the documentation. For example, a
+page that scores `12` before a set of changes, and `9` after, indicates an iterative improvement to
+readability. The score is not an exact science, but is meant to help indicate the general complexity
+level of the page.
 
-The readability score is calculated based on the number of words per sentence,
-and the number of syllables per word. For more information, see
+The readability score is calculated based on the number of words per sentence, and the number of
+syllables per word. For more information, see
 [the Vale documentation](https://docs.errata.ai/vale/styles#metric).
 
 #### Installation
@@ -91,21 +86,20 @@ and the number of syllables per word. For more information, see
 
 ###### macOS
 
-1. Install [Homebrew](https://brew.sh/), which is a package manager for macOS
-   that allows you to easily install programs and tools through the Terminal.
-   Visit their website for installation instructions.
+1. Install [Homebrew](https://brew.sh/), which is a package manager for macOS that allows you to
+   easily install programs and tools through the Terminal. Visit their website for installation
+   instructions.
 1. Follow the
-   [official instructions to install nvm](https://github.com/nvm-sh/nvm#installing-and-updating),
-   a Node version manager. Then, run the following to install and use the
-   repository's Node version:
+   [official instructions to install nvm](https://github.com/nvm-sh/nvm#installing-and-updating), a
+   Node version manager. Then, run the following to install and use the repository's Node version:
 
    ```shell
    nvm install
    nvm use
    ```
 
-   The required Node version should be automatically detected from the `.nvmrc`
-   file. This can be confirmed by running `nvm which`.
+   The required Node version should be automatically detected from the `.nvmrc` file. This can be
+   confirmed by running `nvm which`.
 
 1. Install all dependencies
 
@@ -115,10 +109,9 @@ and the number of syllables per word. For more information, see
 
 ###### Windows (using WSL2)
 
-1. Set up Windows Subsystem for Linux (WSL) and the Linux distribution. WSL
-   allows Linux distributions to run on the Windows OS. Visit this
-   [website](https://docs.microsoft.com/en-us/windows/wsl/install) for more
-   information.
+1. Set up Windows Subsystem for Linux (WSL) and the Linux distribution. WSL allows Linux
+   distributions to run on the Windows OS. Visit this
+   [website](https://docs.microsoft.com/en-us/windows/wsl/install) for more information.
 
    ```powershell
    wsl --install
@@ -135,17 +128,16 @@ and the number of syllables per word. For more information, see
    ```
 
 1. Follow the
-   [official instructions to install nvm](https://github.com/nvm-sh/nvm#installing-and-updating),
-   a Node version manager. Then, run the following to install and use the
-   repository's Node version:
+   [official instructions to install nvm](https://github.com/nvm-sh/nvm#installing-and-updating), a
+   Node version manager. Then, run the following to install and use the repository's Node version:
 
    ```shell
    nvm install
    nvm use
    ```
 
-   The required Node version should be automatically detected from the `.nvmrc`
-   file. This can be confirmed by running `nvm which`.
+   The required Node version should be automatically detected from the `.nvmrc` file. This can be
+   confirmed by running `nvm which`.
 
 #### Install linters
 
@@ -165,11 +157,10 @@ These tools can be [integrated with your code editor](#configure-editors).
 
 ### Configure editors
 
-Using linters in your editor is more convenient than having to run the commands
-from the command line.
+Using linters in your editor is more convenient than having to run the commands from the command
+line.
 
-To configure `prettier` in your editor, install one of the following as
-appropriate:
+To configure `prettier` in your editor, install one of the following as appropriate:
 
 - Visual Studio Code
   [`esbenp.prettier-vscode` extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode).
@@ -181,8 +172,7 @@ To configure Vale in your editor, install one of the following as appropriate:
 
 ### Lint checks
 
-The following commands can be run to format all Markdown files across the entire
-repository:
+The following commands can be run to format all Markdown files across the entire repository:
 
 ```shell
 # Format markdown style (fixing markdown style issues)
@@ -200,6 +190,5 @@ npm run prose:check
 
 ## Contributing guidelines
 
-Contributing formatting guidelines, including git workflow and commit formatting
-requirements can be found in our
-[git contribution guide](docs/processes/quality-assurance/git-contribution-guide.md).
+Contributing formatting guidelines, including git workflow and commit formatting requirements can be
+found in our [git contribution guide](docs/processes/quality-assurance/git-contribution-guide.md).

--- a/docs/communication/fearless-feedback.md
+++ b/docs/communication/fearless-feedback.md
@@ -11,11 +11,15 @@
   - [LADA Model](#lada-model)
 - [Key takeaways](#key-takeaways)
 
-Fearless feedback is feedback, which is direct, honest, timely, brief, constructive, and provided with good intention.
+Fearless feedback is feedback, which is direct, honest, timely, brief, constructive, and provided
+with good intention.
 
-Many people struggle with giving or receiving feedback, which is normal. If the feedback is delivered poorly, people can reflex to defend or protect.
+Many people struggle with giving or receiving feedback, which is normal. If the feedback is
+delivered poorly, people can reflex to defend or protect.
 
-Feedback, however, is integral to growth and confidence - through celebrating achievements, validating actions or opinions, and learning. It provides a mutual understanding of a situation, action, or emotion, to allow for easy and respectful communication.
+Feedback, however, is integral to growth and confidence - through celebrating achievements,
+validating actions or opinions, and learning. It provides a mutual understanding of a situation,
+action, or emotion, to allow for easy and respectful communication.
 
 ## Feedback matrix
 
@@ -35,9 +39,11 @@ There are four distinct types of feedback that exist on this spectrum.
 >
 > Negative, general: "_Emerald, I saw that PR you put through. It was really bad._"
 >
-> Positive, specific: "_Harold, you did a great presentation on Wednesday, you were so confident. I learned a lot about how to use GitHub._"
+> Positive, specific: "_Harold, you did a great presentation on Wednesday, you were so confident. I
+> learned a lot about how to use GitHub._"
 >
-> Negative, specific: "_Emerald, I saw PR #70, some of the naming conventions were did not follow the contribution guide, making it hard to understand._"
+> Negative, specific: "_Emerald, I saw PR #70, some of the naming conventions were did not follow
+> the contribution guide, making it hard to understand._"
 
 Key takeaways:
 
@@ -48,19 +54,40 @@ Key takeaways:
 
 ## Delivering feedback
 
-When delivering feedback, it is important to **ask for permission beforehand**. It is expected that some days are not going to be an appropriate time for feedback. Please do not deliver feedback when you or they are upset or angry. For feedback to be productive it is best to be level-headed. Willingness to listen and respect the feedback is a major part of the process. The outcome will not be productive if you or they are not willing to listen with an open-mind.
+When delivering feedback, it is important to **ask for permission beforehand**. It is expected that
+some days are not going to be an appropriate time for feedback. Please do not deliver feedback when
+you or they are upset or angry. For feedback to be productive it is best to be level-headed.
+Willingness to listen and respect the feedback is a major part of the process. The outcome will not
+be productive if you or they are not willing to listen with an open-mind.
 
-It can be as simple as a quick message: "_Is now an okay time for some feedback?_", "_Would you be willing to hear some feedback from me?_", or "_Are you open to some feedback from me?_".
+It can be as simple as a quick message: "_Is now an okay time for some feedback?_", "_Would you be
+willing to hear some feedback from me?_", or "_Are you open to some feedback from me?_".
 
-Feedback is used to help someone improve and learn, it is not a criticism of a person's skills or intelligence. **Assuming positive intent**, from both parties, in all feedback can reduce miscommunication or offence. However, this is a skill that takes time and practice.
+Feedback is used to help someone improve and learn, it is not a criticism of a person's skills or
+intelligence. **Assuming positive intent**, from both parties, in all feedback can reduce
+miscommunication or offence. However, this is a skill that takes time and practice.
 
-This is particularly important when providing constructive feedback, it is important to always **seek to understand** the root cause and context for a situation. Never assume to know everything about a person and make judgements. Feedback is designed to provide opportunities and create conversations for improvement. Being open to listen to the whole context can allow you to provide more specific and productive feedback, which is more beneficial for the individual.
+This is particularly important when providing constructive feedback, it is important to always
+**seek to understand** the root cause and context for a situation. Never assume to know everything
+about a person and make judgements. Feedback is designed to provide opportunities and create
+conversations for improvement. Being open to listen to the whole context can allow you to provide
+more specific and productive feedback, which is more beneficial for the individual.
 
-**Building relationships** with each other can help facilitate the feedback process. The stronger your rapport the more honest the feedback. However, rapport does not dismiss professionalism, feedback can be critical, and it is important that it follows communication guideline and standards. Be proactive and ask for feedback from your peers, do not wait for someone to find you. If you ask for general feedback, you should expect a general response.
+**Building relationships** with each other can help facilitate the feedback process. The stronger
+your rapport the more honest the feedback. However, rapport does not dismiss professionalism,
+feedback can be critical, and it is important that it follows communication guideline and standards.
+Be proactive and ask for feedback from your peers, do not wait for someone to find you. If you ask
+for general feedback, you should expect a general response.
 
-The environment can play a influential role in the willingness and reaction to feedback. **Creating a safe space** allows for effective and professional communication. For one-on-one feedback, take it to a private space and be available for an active discussion around the feedback. Ensure that there are no non-verbal power imbalances within the discussion (e.g. You standing, and them sitting).
+The environment can play a influential role in the willingness and reaction to feedback. **Creating
+a safe space** allows for effective and professional communication. For one-on-one feedback, take it
+to a private space and be available for an active discussion around the feedback. Ensure that there
+are no non-verbal power imbalances within the discussion (e.g. You standing, and them sitting).
 
-How you **frame the feedback** can influence the discussion. Feedback, especially negative feedback, is not a trifle comment, it is shaped around context and values. Different models for feedback exist, such as the Compliment Sandwich, AID model, or the GROW model. Breaking the feedback into actionable sections can also help in understanding and plans going forwards.
+How you **frame the feedback** can influence the discussion. Feedback, especially negative feedback,
+is not a trifle comment, it is shaped around context and values. Different models for feedback
+exist, such as the Compliment Sandwich, AID model, or the GROW model. Breaking the feedback into
+actionable sections can also help in understanding and plans going forwards.
 
 ### Compliment Sandwich
 
@@ -69,7 +96,9 @@ How you **frame the feedback** can influence the discussion. Feedback, especiall
   A[Positive] --> B[Negative] --> C[Positive]
 ```
 
-The Compliment Sandwich wraps constructive criticism within praise. This can be useful for people who you do not have rapport or if you are new to giving feedback. It is an easy and less destructive model to provide feedback.
+The Compliment Sandwich wraps constructive criticism within praise. This can be useful for people
+who you do not have rapport or if you are new to giving feedback. It is an easy and less destructive
+model to provide feedback.
 
 ### AID model
 
@@ -78,13 +107,18 @@ The Compliment Sandwich wraps constructive criticism within praise. This can be 
   A[Action] --> I[Impact] --> D[Development] & B[Desired Behaviour]
 ```
 
-**Action:** the emphasis is on the actions, rather than the interpretation of it. All feedback relates to what is heard or observed, not intentions, characteristics, or personality.
+**Action:** the emphasis is on the actions, rather than the interpretation of it. All feedback
+relates to what is heard or observed, not intentions, characteristics, or personality.
 
-**Impact:** this acknowledges the impact of the end result or the process itself. When giving feedback mention why it is important that this action is changed or continued.
+**Impact:** this acknowledges the impact of the end result or the process itself. When giving
+feedback mention why it is important that this action is changed or continued.
 
-**Development or Desired Behaviour:** the purpose of feedback is to provide learning opportunties or praise. Put emphasis on what is missing rather than what went wrong. Provide direction on how they can improve and plan a time to meet again to review.
+**Development or Desired Behaviour:** the purpose of feedback is to provide learning opportunties or
+praise. Put emphasis on what is missing rather than what went wrong. Provide direction on how they
+can improve and plan a time to meet again to review.
 
-The AID model is a simple feedback model for both positive and negative moments. It focuses uses evidence to relate feedback into the context, rather than relying on rapport.
+The AID model is a simple feedback model for both positive and negative moments. It focuses uses
+evidence to relate feedback into the context, rather than relying on rapport.
 
 ### GROW model
 
@@ -101,31 +135,53 @@ The AID model is a simple feedback model for both positive and negative moments.
 
 **Will:** What will be done now? What are the next steps? Your opinion?
 
-The GROW model is for deeper conversation around feedback. This framework naturally places feedback within the context of the team or project goals. It is also important that you ask yourself these questions. One should reflect and facilitate self-development and awareness before providing feedback.
+The GROW model is for deeper conversation around feedback. This framework naturally places feedback
+within the context of the team or project goals. It is also important that you ask yourself these
+questions. One should reflect and facilitate self-development and awareness before providing
+feedback.
 
 ### Shoutouts
 
-Recognition is a key transformative tactic. Showing appreciation to team members contributions influences engagement behaviour and acknowledges to team members that their work is seen. This can be a way to build rapport, by showing you see all aspects of their contributons.
+Recognition is a key transformative tactic. Showing appreciation to team members contributions
+influences engagement behaviour and acknowledges to team members that their work is seen. This can
+be a way to build rapport, by showing you see all aspects of their contributons.
 
-1. Shout out to people that did a great job in our `Shoutouts!` MS Teams channel. Everyone in the company is in this channel so please do not be shy.
+1. Shout out to people that did a great job in our `Shoutouts!` MS Teams channel. Everyone in the
+   company is in this channel so please do not be shy.
 1. Consider other channels where recognition can be acknowledged: team meetings, etc.
 1. Please be as timely as possible with your recognition.
 
 ## Receiving feedback
 
-Receiving feedback follows similar principles to delivery, however, in this case it is the response that changes.
+Receiving feedback follows similar principles to delivery, however, in this case it is the response
+that changes.
 
-**Mentally prepare to receive the feedback**. Ideally, you should have given permission or asked for the feedback. Reflect and ask yourself "_are you in a good mindset to receive feedbaack?_" when being asked permision. It is okay to say "_now is not the right time, but what about tomorrow morning?_".
+**Mentally prepare to receive the feedback**. Ideally, you should have given permission or asked for
+the feedback. Reflect and ask yourself "_are you in a good mindset to receive feedbaack?_" when
+being asked permision. It is okay to say "_now is not the right time, but what about tomorrow
+morning?_".
 
-Be patient, now is the time to acknowledge and listen to the advice given. **Develop a growth mindset**. This will help you step back from the defence and accept feedback to improve and learn. Again, you should always **assume positive intent**. Feedback is not a criticism on the work done, it is merely advice to improve and be even better next time around.
+Be patient, now is the time to acknowledge and listen to the advice given. **Develop a growth
+mindset**. This will help you step back from the defence and accept feedback to improve and learn.
+Again, you should always **assume positive intent**. Feedback is not a criticism on the work done,
+it is merely advice to improve and be even better next time around.
 
-**Use active listening skills**. Do not interrupt them as they are speaking. Listen to the whole story, rather than formulate challenges and excuses. Active listeners avoid interrputing, summarise the information, repeat back what they have heard, and observe body language. This will help with using a growth mindset, allowing you to focus on the person, rather than your own thoughts.
+**Use active listening skills**. Do not interrupt them as they are speaking. Listen to the whole
+story, rather than formulate challenges and excuses. Active listeners avoid interrputing, summarise
+the information, repeat back what they have heard, and observe body language. This will help with
+using a growth mindset, allowing you to focus on the person, rather than your own thoughts.
 
-The **first response should be gratitude**. Giving feedback takes courage and can be risky. People are often reluctant to share all their thoughts, creating a safe space can allow them to extract all feedback. Saying "_Thank you_" will put you in a constructive frame of mind. Gratitude demonstrates you are willing to listen and learn.
+The **first response should be gratitude**. Giving feedback takes courage and can be risky. People
+are often reluctant to share all their thoughts, creating a safe space can allow them to extract all
+feedback. Saying "_Thank you_" will put you in a constructive frame of mind. Gratitude demonstrates
+you are willing to listen and learn.
 
 <!-- WIP: If you are ever uncomfortable with a setting, say something. They may be unaware of the situation or feeling arising. Feedback should be a learning opportunity, not a -->
 
-If you want more specific information, take the time to restate what they have told you, and ask. **Seeking to understand** goes both ways. Even if you disagree with some of the message, there is always something to learn. Actively trying to understand another perspective can help you to reach their conclusions.
+If you want more specific information, take the time to restate what they have told you, and ask.
+**Seeking to understand** goes both ways. Even if you disagree with some of the message, there is
+always something to learn. Actively trying to understand another perspective can help you to reach
+their conclusions.
 
 Similar to delivering feedback, there are some frameworks you can employ.
 
@@ -136,10 +192,12 @@ Similar to delivering feedback, there are some frameworks you can employ.
   G[Gratitude] --> A[Agreement] --> C[Common Ground] --> D[Discussion] --> G
 ```
 
-It is okay to disagree with some of the feedback. However, it is important to be conscious of the risk they have taken in giving feedback.
-Always state where you agree before discussing where you disagree.
-Agreement is a much similar conversation and can be short. It will also make you seem less defensive, leading to a more productive conversation following.
-Disagreement is a much larger discussion. You do not have to agree with their feedback. However, you should seek to understand where they are coming from. Odds are they are not the only one who thinks this way.
+It is okay to disagree with some of the feedback. However, it is important to be conscious of the
+risk they have taken in giving feedback. Always state where you agree before discussing where you
+disagree. Agreement is a much similar conversation and can be short. It will also make you seem less
+defensive, leading to a more productive conversation following. Disagreement is a much larger
+discussion. You do not have to agree with their feedback. However, you should seek to understand
+where they are coming from. Odds are they are not the only one who thinks this way.
 
 ### LADA Model
 
@@ -148,24 +206,37 @@ Disagreement is a much larger discussion. You do not have to agree with their fe
   L[Listen] --> A[Absorb] --> D[Decide] --> B[Act]
 ```
 
-**Listen:** Listening to the other person allows the other person to express and refine their thoughts. Be patient. Ask questions like "_Is there anything else you want to tell me?_" or "_Feel free to send more feedback if you think of anything else_". Be mindful of the tone of your voice.
+**Listen:** Listening to the other person allows the other person to express and refine their
+thoughts. Be patient. Ask questions like "_Is there anything else you want to tell me?_" or "_Feel
+free to send more feedback if you think of anything else_". Be mindful of the tone of your voice.
 
-**Absorb:** Take the time to seek to understand and clarify the feedback given to you. Asking questions for clarification and examples can help to build a more detailed understanding. These are not posed as a challenge to the person, but to receive and absorb. Questions can be:
+**Absorb:** Take the time to seek to understand and clarify the feedback given to you. Asking
+questions for clarification and examples can help to build a more detailed understanding. These are
+not posed as a challenge to the person, but to receive and absorb. Questions can be:
 
 - Can you give me an example?
 - What would you have done?
 - What would your preference have been?
 
-If all the feedback is positive, it can be difficult to identify the areas for growth. Some questions to help are:
+If all the feedback is positive, it can be difficult to identify the areas for growth. Some
+questions to help are:
 
 - Is there something that you think I can improve on?
 - Do you think I could have done something differently?
 
-**Decide:** This stage is occurs both during the conversation and after. It is reflection and introspection. Here you decide whether the feedback is legitimate and something to be actioned. It is important not to become defensive, but you can disagree with the feedback. To disagree must be polite and can be discussed with the giver. The deciding stage can help with prioritising the actions to address.
+**Decide:** This stage is occurs both during the conversation and after. It is reflection and
+introspection. Here you decide whether the feedback is legitimate and something to be actioned. It
+is important not to become defensive, but you can disagree with the feedback. To disagree must be
+polite and can be discussed with the giver. The deciding stage can help with prioritising the
+actions to address.
 
-**Act:** This stage is about creating actionable items derived from feedback. Not all feedback is actionable through outcomes or goals. Some feedback is about awareness and is highly situational. It is an important skill to learn how to action and assess feedback.
+**Act:** This stage is about creating actionable items derived from feedback. Not all feedback is
+actionable through outcomes or goals. Some feedback is about awareness and is highly situational. It
+is an important skill to learn how to action and assess feedback.
 
-The LADA model encourages the giver to freely convey their thoughts and you to dig deeper into the details of the feedback. By asking questions and going further you may uncover added information that might be valuable to your learning.
+The LADA model encourages the giver to freely convey their thoughts and you to dig deeper into the
+details of the feedback. By asking questions and going further you may uncover added information
+that might be valuable to your learning.
 
 ## Key takeaways
 

--- a/docs/communication/index.md
+++ b/docs/communication/index.md
@@ -1,15 +1,14 @@
 # Communication
 
-At Thoth Tech, our employees work remotely in various time zones and have
-different commitments outside of work. It is important for us to practice
-clear communication in ways that help us stay connected and work more
-efficiently.
+At Thoth Tech, our employees work remotely in various time zones and have different commitments
+outside of work. It is important for us to practice clear communication in ways that help us stay
+connected and work more efficiently.
 
-To accomplish this, we stay as open and transparent as we can and bias towards
-asynchronous communication as starting point.
+To accomplish this, we stay as open and transparent as we can and bias towards asynchronous
+communication as starting point.
 
-We place emphasis on documentation and ensure that decisions and conclusions
-are written down and accessible to everyone in the company.
+We place emphasis on documentation and ensure that decisions and conclusions are written down and
+accessible to everyone in the company.
 
 ## Guidelines
 
@@ -18,7 +17,8 @@ are written down and accessible to everyone in the company.
 3. Use chat / direct message for private or personal discussion
 4. Use GitHub Pull Requests for feedback on code or documentation
 5. Use Trello for planning and assigning tasks
-6. Use meetings for synchronous discussion _(for private channels, record and store the meeting in the channel files)_
+6. Use meetings for synchronous discussion _(for private channels, record and store the meeting in
+   the channel files)_
 7. Use whiteboard tools (Miro or MS) to collaborate in meetings
 
 For more information:

--- a/docs/communication/professional-communication.md
+++ b/docs/communication/professional-communication.md
@@ -5,9 +5,12 @@
 - [How can you improve your communication skills?](#how-can-you-improve-your-communication-skills)
 - [Professional communication at Thoth Tech](#professional-communication-at-thoth-tech)
 
-Professional communication is important at Thoth Tech as it embodies our values. As we move into a hybrid framework, we must respect those both remote and face-to-face. Communication goes a long way to creating a respectful and supportive workplace culture.
+Professional communication is important at Thoth Tech as it embodies our values. As we move into a
+hybrid framework, we must respect those both remote and face-to-face. Communication goes a long way
+to creating a respectful and supportive workplace culture.
 
-Communication extends beyond the words we speak. There are many different forms of communication, and it is important to build these skills. The types of communication identified at Thoth Tech are:
+Communication extends beyond the words we speak. There are many different forms of communication,
+and it is important to build these skills. The types of communication identified at Thoth Tech are:
 
 - oral communication
 - written communication
@@ -16,7 +19,9 @@ Communication extends beyond the words we speak. There are many different forms 
 
 ## Why is professional communication important?
 
-Communication is at the centre of our work. All forms of communication can be used to inform, influence, educate, persuade, and respond. Our skill in communication can determined the outcome and next steps of a meeting or project.
+Communication is at the centre of our work. All forms of communication can be used to inform,
+influence, educate, persuade, and respond. Our skill in communication can determined the outcome and
+next steps of a meeting or project.
 
 - It can ensure you pick the right style for the audience.
 - It is a desirable soft skill.
@@ -27,14 +32,16 @@ Communication is at the centre of our work. All forms of communication can be us
 
 ## What makes up professional communication?
 
-There are four basic skills that are intertwined with each communication type. These skills make up effective communication:
+There are four basic skills that are intertwined with each communication type. These skills make up
+effective communication:
 
 - listening
 - reading
 - writing
 - speaking
 
-Effective communication differs from professional communication. For communication to be professional, it is important that it is:
+Effective communication differs from professional communication. For communication to be
+professional, it is important that it is:
 
 - complete
 - polite
@@ -48,7 +55,8 @@ Effective communication differs from professional communication. For communicati
 
 ## How can you improve your communication skills?
 
-There are many barriers to professional communication. However, like any other skill, this can be learnt with time and practice. Some tips to improve your skills:
+There are many barriers to professional communication. However, like any other skill, this can be
+learnt with time and practice. Some tips to improve your skills:
 
 - Ask for feedback
 - Learn from others
@@ -63,8 +71,11 @@ There are many barriers to professional communication. However, like any other s
 
 ## Professional communication at Thoth Tech
 
-1. Use formal or semi-formal language when contacting someone for the first time and try to build rapport.
-2. Be respectful of a person's time. We do not expect you to be available all the time and neither should your peers. If you want someone's attention, schedule meetings in advance or give a heads up.
+1. Use formal or semi-formal language when contacting someone for the first time and try to build
+   rapport.
+2. Be respectful of a person's time. We do not expect you to be available all the time and neither
+   should your peers. If you want someone's attention, schedule meetings in advance or give a heads
+   up.
 3. All company data should be shareable by default.
 4. Use emoticons to brighten the mood but be sparing.
 5. Provide meaningful responses in an appropriate time frame.
@@ -73,4 +84,5 @@ There are many barriers to professional communication. However, like any other s
 8. Use Pull Requests or public chat channels instead of direct messages.
 9. Handle conflicts with diplomacy and an open mind.
 10. Avoid controversial topics and gossip.
-11. Offer [praise](fearless-feedback.md#shoutouts) and [fearless feedback](fearless-feedback.md#fearless-feedback).
+11. Offer [praise](fearless-feedback.md#shoutouts) and
+    [fearless feedback](fearless-feedback.md#fearless-feedback).

--- a/docs/communication/scenarios.md
+++ b/docs/communication/scenarios.md
@@ -1,9 +1,8 @@
 # Communication scenarios <!-- omit in toc -->
 
-At Thoth Tech, the Area Leads have identified a number of communication
-scenarios which can be difficult to manage. In each scenario there are
-different outcomes and courses of action. Below are the learnings that
-came out of these scenarios.
+At Thoth Tech, the Area Leads have identified a number of communication scenarios which can be
+difficult to manage. In each scenario there are different outcomes and courses of action. Below are
+the learnings that came out of these scenarios.
 
 - [Company communication](#company-communication)
 - [Technical difficulties](#technical-difficulties)

--- a/docs/company/charter.md
+++ b/docs/company/charter.md
@@ -1,10 +1,9 @@
 # Charter
 
-The Thoth Tech charter is important for steering our team in the right direction,
-establishing boundaries, and aligning the team on how they want to work into the
-future. If every member of the team is clear on their roles, responsibilities,
-and purpose, they can focus on the relevant things — reducing the risk of
-inefficiencies, misunderstandings, and duplicate work.
+The Thoth Tech charter is important for steering our team in the right direction, establishing
+boundaries, and aligning the team on how they want to work into the future. If every member of the
+team is clear on their roles, responsibilities, and purpose, they can focus on the relevant things —
+reducing the risk of inefficiencies, misunderstandings, and duplicate work.
 
 Our charter comprises of the following areas:
 
@@ -17,36 +16,32 @@ Our charter comprises of the following areas:
 
 ## Mission
 
-To build, operate and deploy world class education technologies. This is
-achieved by creating tools that enhance education outcomes by empowering
-students, connecting them with tutors and facilitating personalised learning
-experiences.
+To build, operate and deploy world class education technologies. This is achieved by creating tools
+that enhance education outcomes by empowering students, connecting them with tutors and facilitating
+personalised learning experiences.
 
 ## Values
 
-Our values describe how we work, what we represent, and guide us to be the
-kind of company and team members we want to be. When we live up to these values we will:
+Our values describe how we work, what we represent, and guide us to be the kind of company and team
+members we want to be. When we live up to these values we will:
 
 ### Be people-focused
 
-We expect the best from each other, give each other the benefit of the doubt,
-encourage each other to take initiative to improve ourselves and the company,
-and provide direct and constructive help to each other. We collaborate with
-kindness while being respectful of each other.
+We expect the best from each other, give each other the benefit of the doubt, encourage each other
+to take initiative to improve ourselves and the company, and provide direct and constructive help to
+each other. We collaborate with kindness while being respectful of each other.
 
 ### Uphold sustainable excellence
 
-We create working, maintainable, and understandable software that is
-enjoyable and easy to use. We strive to do it in the way that is
-sustainable to our team members and to our environment.
+We create working, maintainable, and understandable software that is enjoyable and easy to use. We
+strive to do it in the way that is sustainable to our team members and to our environment.
 
 ### Be inclusive and supportive
 
-We celebrate diverse perspectives and embrace uncomfortable ideas and
-conversations. We facilitate an environment in which all team members
-feel psychologically safe enough to make requests for what they need
-in order to do their job. We learn through failures while continually
-working to make things better.
+We celebrate diverse perspectives and embrace uncomfortable ideas and conversations. We facilitate
+an environment in which all team members feel psychologically safe enough to make requests for what
+they need in order to do their job. We learn through failures while continually working to make
+things better.
 
 ## Group norms
 

--- a/docs/company/reports/t1-2022/company-report-v1.md
+++ b/docs/company/reports/t1-2022/company-report-v1.md
@@ -10,17 +10,41 @@ T1 Report 2022: Week 3
 
 ## Executive Summary
 
-Thoth Tech (est. 2022) is a new software development company currently building from the ground up in Melbourne Australia. Thoth Tech’s mission is to build, operate, and deploy education technologies, creating tools that enhance education outcomes by empowering students, connecting them with tutors, and facilitating personalised learning experiences. We value our people, and we value excellence: We are people-focused, aim to produce sustainable products of excellent quality, and provide frameworks that provide a safe environment for learning and support of our team.
+Thoth Tech (est. 2022) is a new software development company currently building from the ground up
+in Melbourne Australia. Thoth Tech’s mission is to build, operate, and deploy education
+technologies, creating tools that enhance education outcomes by empowering students, connecting them
+with tutors, and facilitating personalised learning experiences. We value our people, and we value
+excellence: We are people-focused, aim to produce sustainable products of excellent quality, and
+provide frameworks that provide a safe environment for learning and support of our team.
 
-This report is for stakeholders, investors, and employees, and will outline the company structure, charter, objectives – both short and long term, and explore each product’s goals in depth.
+This report is for stakeholders, investors, and employees, and will outline the company structure,
+charter, objectives – both short and long term, and explore each product’s goals in depth.
 
-Within the first third of 2022, Thoth Tech has recruited approximately 92 employees including four area leads, three product leads and eleven delivery leads. There will be another recruitment phase during the other two thirds of the year and an expected exit rate of 50 percent, with the potential for internships throughout the company.
+Within the first third of 2022, Thoth Tech has recruited approximately 92 employees including four
+area leads, three product leads and eleven delivery leads. There will be another recruitment phase
+during the other two thirds of the year and an expected exit rate of 50 percent, with the potential
+for internships throughout the company.
 
-Along with recruitment, Thoth Tech has taken onboard three external products, two live and well-established products – _OnTrack_ and _SplashKit_ – and _DreamBig_, a in development product which will leverage the OnTrack technology stack. Thoth Tech will also be creating our internal architecture and platform for employees throughout this third of the year, referred to as the _Internal System_ project.
+Along with recruitment, Thoth Tech has taken onboard three external products, two live and
+well-established products – _OnTrack_ and _SplashKit_ – and _DreamBig_, a in development product
+which will leverage the OnTrack technology stack. Thoth Tech will also be creating our internal
+architecture and platform for employees throughout this third of the year, referred to as the
+_Internal System_ project.
 
-Both the OnTrack and SplashKit products have been identified as requiring extensions and additional features to improve the quality and usability of the product. OnTrack is a platform designed to facilitate student learning and reducing the pressure of achieving unrealistic grades. The focus is on providing a tailored learning experience, using tasks and a portfolio assessment. This product is live and is currently being upgraded to newer technology stacks and improving security and documentation. SplashKit is currently a 2D game development Software Development Kit used to teach object-oriented coding to beginners. It has been identified that SplashKit can be expanded to explore other areas and languages. The DreamBig product is in response to a need identified by Deakin, to provide a personalised development roadmaps to enhance students’ employability.
+Both the OnTrack and SplashKit products have been identified as requiring extensions and additional
+features to improve the quality and usability of the product. OnTrack is a platform designed to
+facilitate student learning and reducing the pressure of achieving unrealistic grades. The focus is
+on providing a tailored learning experience, using tasks and a portfolio assessment. This product is
+live and is currently being upgraded to newer technology stacks and improving security and
+documentation. SplashKit is currently a 2D game development Software Development Kit used to teach
+object-oriented coding to beginners. It has been identified that SplashKit can be expanded to
+explore other areas and languages. The DreamBig product is in response to a need identified by
+Deakin, to provide a personalised development roadmaps to enhance students’ employability.
 
-Due to a partnership with the School of IT at Deakin University, Thoth Tech and the subsequent products are funded, supported, and leveraged by Deakin. However, all contributions by Thoth Tech members are acknowledged due to the Open-Source nature of the company. Deakin provides ground zero end-user testing and focus groups for product improvements.
+Due to a partnership with the School of IT at Deakin University, Thoth Tech and the subsequent
+products are funded, supported, and leveraged by Deakin. However, all contributions by Thoth Tech
+members are acknowledged due to the Open-Source nature of the company. Deakin provides ground zero
+end-user testing and focus groups for product improvements.
 
 \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
 
@@ -102,7 +126,8 @@ This trimester, Thoth Tech has set out to achieve the following objectives:
 - Establish a handover and Offboarding process.
 - Establish an internal website for centralised documentation visibility.
 
-**Objective 2: Create a safe, supportive, and collaborative company culture that empowers our employees to learn and develop their skills.**
+**Objective 2: Create a safe, supportive, and collaborative company culture that empowers our
+employees to learn and develop their skills.**
 
 - Create a company culture where feedback is welcome, and success is celebrated.
 - Support development of chosen skills in every team member.
@@ -127,14 +152,17 @@ This trimester, Thoth Tech has set out to achieve the following objectives:
 - Move Ontrack front-end away from legacy technologies.
 - Analyse, update, improve and create retrospective OnTrack documentation.
 
-**Objective 5: Create the DreamBig prototype as a new product that adds value to the Thoth Tech company**
+**Objective 5: Create the DreamBig prototype as a new product that adds value to the Thoth Tech
+company**
 
 - Build the vision and strategy for the DreamBig product.
 - Create a DreamBig prototype as proof of concept.
 
 # Company Charter
 
-The Thoth Tech charter is a crucial tool for guiding our team, navigating decisions, establishing boundaries, and aligning the team on how we work together. It defines how as a company we work together to achieve success.
+The Thoth Tech charter is a crucial tool for guiding our team, navigating decisions, establishing
+boundaries, and aligning the team on how we work together. It defines how as a company we work
+together to achieve success.
 
 Our charter comprises of the following:
 
@@ -147,23 +175,32 @@ Our charter comprises of the following:
 
 ## Mission
 
-Our mission is to build, operate and deploy world class education technologies. This is achieved by creating accessible tools that enhance education outcomes by empowering students, connecting them with tutors and facilitating personalised learning experiences.
+Our mission is to build, operate and deploy world class education technologies. This is achieved by
+creating accessible tools that enhance education outcomes by empowering students, connecting them
+with tutors and facilitating personalised learning experiences.
 
 ## Values
 
-Our values describe how we work, what we represent, and guide us to be the kind of company and team members we want to be. When we live up to these values we will:
+Our values describe how we work, what we represent, and guide us to be the kind of company and team
+members we want to be. When we live up to these values we will:
 
 **Be people-focused**
 
-We expect the best from each other, give each other the benefit of the doubt, encourage each other to take initiative to improve ourselves and the company, and provide direct and constructive help to each other. We collaborate with kindness while being respectful of each other.
+We expect the best from each other, give each other the benefit of the doubt, encourage each other
+to take initiative to improve ourselves and the company, and provide direct and constructive help to
+each other. We collaborate with kindness while being respectful of each other.
 
 **Uphold sustainable excellence**
 
-We create working, maintainable, and understandable software that is enjoyable and easy to use. We strive to do it in a way that is sustainable for our team members and for our environment.
+We create working, maintainable, and understandable software that is enjoyable and easy to use. We
+strive to do it in a way that is sustainable for our team members and for our environment.
 
 **Be inclusive and supportive**
 
-We celebrate diverse perspectives and embrace uncomfortable ideas and conversations. We facilitate an environment in which all team members feel psychologically safe enough to make requests for what they need to do their job. We learn through failures while continually working to make things better.
+We celebrate diverse perspectives and embrace uncomfortable ideas and conversations. We facilitate
+an environment in which all team members feel psychologically safe enough to make requests for what
+they need to do their job. We learn through failures while continually working to make things
+better.
 
 ## Team Culture
 
@@ -195,23 +232,37 @@ We celebrate diverse perspectives and embrace uncomfortable ideas and conversati
 
 # Company Structure
 
-The Company is broken up based on product, with the area leads spread company wide. There is a tier system built into the company structure – directors, area leads, product leads, delivery leads, then team members. This structure is primarily about support, guidance, and feedback, rather than authority.
+The Company is broken up based on product, with the area leads spread company wide. There is a tier
+system built into the company structure – directors, area leads, product leads, delivery leads, then
+team members. This structure is primarily about support, guidance, and feedback, rather than
+authority.
 
-Each employee has chosen their own role title based on their interests, skills, experience and what they want to develop.
+Each employee has chosen their own role title based on their interests, skills, experience and what
+they want to develop.
 
-The company structure is linked [here](https://deakin365.sharepoint.com/:b:/s/ThothTech2-Leadership/ERuLF9JWzz5HvF68OG7D_EgBQ14uMdrGKXuS2fvNEWE_WQ?e=ihX3Wt) and available on the next page.
+The company structure is linked
+[here](https://deakin365.sharepoint.com/:b:/s/ThothTech2-Leadership/ERuLF9JWzz5HvF68OG7D_EgBQ14uMdrGKXuS2fvNEWE_WQ?e=ihX3Wt)
+and available on the next page.
 
 ![](Aspose.Words.7698171d-24c6-484d-8064-ccc609e55c08.004.png)
 
 # Product Overview
 
-Thoth Tech currently has two existing products, OnTrack and SplashKit, which are open source and live to users. Thoth Tech also has two products in development, a third external product called DreamBig, and an Internal Systems product for Thoth Tech employees. Each product is being developed during this trimester.
+Thoth Tech currently has two existing products, OnTrack and SplashKit, which are open source and
+live to users. Thoth Tech also has two products in development, a third external product called
+DreamBig, and an Internal Systems product for Thoth Tech employees. Each product is being developed
+during this trimester.
 
 ## OnTrack
 
-OnTrack is a platform designed to facilitate student learning by helping them achieve their unit learning outcomes and goals. It reduces pressure on achieving unrealistic grades, and importance on tailored content learning using tasks and a portfolio assessment.
+OnTrack is a platform designed to facilitate student learning by helping them achieve their unit
+learning outcomes and goals. It reduces pressure on achieving unrealistic grades, and importance on
+tailored content learning using tasks and a portfolio assessment.
 
-This approach provides students with a simple but effective way to demonstrate their achievements and learning outcomes with the assistance of teaching staff feedback throughout the unit. OnTrack is based on Doubtfire LMS and Thoth Tech is working towards creating new and enhanced features that improve the teaching and learning experience.
+This approach provides students with a simple but effective way to demonstrate their achievements
+and learning outcomes with the assistance of teaching staff feedback throughout the unit. OnTrack is
+based on Doubtfire LMS and Thoth Tech is working towards creating new and enhanced features that
+improve the teaching and learning experience.
 
 **Product Lead:** Jordan Cameron Trainor
 
@@ -219,21 +270,41 @@ This approach provides students with a simple but effective way to demonstrate t
 
 #### _Overview, Goals, and Objectives_
 
-The Front-end migration project aims to modernise the existing components that use CoffeeScript and Bootstrap, towards the cutting-edge framework, Angular with Typescript. CoffeeScript has become dated and lacks the functionality, security, and support that more modern frameworks provide. Angular, which is supported by Google, allows developers to leverage its component-based architecture to quickly create dynamic single-page applications. It is built using TypeScript, which ensures greater security as the language supports types and allows for early bug detection. Other features include templating, two-way binding, dependency injection, and extending HTML syntax without relying on third-party libraries. Moving to Angular will continue to uphold the integrity of OnTrack. TypeScript is accepted by a larger community base and includes more advanced and scalable features. Once migrations are completed, it’s possible to add more advanced and quicker features to OnTrack.
+The Front-end migration project aims to modernise the existing components that use CoffeeScript and
+Bootstrap, towards the cutting-edge framework, Angular with Typescript. CoffeeScript has become
+dated and lacks the functionality, security, and support that more modern frameworks provide.
+Angular, which is supported by Google, allows developers to leverage its component-based
+architecture to quickly create dynamic single-page applications. It is built using TypeScript, which
+ensures greater security as the language supports types and allows for early bug detection. Other
+features include templating, two-way binding, dependency injection, and extending HTML syntax
+without relying on third-party libraries. Moving to Angular will continue to uphold the integrity of
+OnTrack. TypeScript is accepted by a larger community base and includes more advanced and scalable
+features. Once migrations are completed, it’s possible to add more advanced and quicker features to
+OnTrack.
 
 #### _Aims for Trimester_
 
-The aim for the trimester is for each of the eight teams within the project to migrate at least one existing component and build experience to enable accelerated progress in future trimesters by supporting future team members.
+The aim for the trimester is for each of the eight teams within the project to migrate at least one
+existing component and build experience to enable accelerated progress in future trimesters by
+supporting future team members.
 
 #### _Deliverables_
 
-The Front-End migration team has taken a divide and conquer approach by allocating two people into a sub-team to ensure the amount of work is well distributed. This will allow for easier communication, teamwork, and workflow for more efficient progress.
+The Front-End migration team has taken a divide and conquer approach by allocating two people into a
+sub-team to ensure the amount of work is well distributed. This will allow for easier communication,
+teamwork, and workflow for more efficient progress.
 
-Based on existing documentation, there are 183 components remaining to migrate, however this may not be accurately updated. An analysis will be completed to ensure this is updated.
+Based on existing documentation, there are 183 components remaining to migrate, however this may not
+be accurately updated. An analysis will be completed to ensure this is updated.
 
-The trimester deliverables will be developing and delivering at least eight migrated components. However, the long-term project deliverables are to ensure all future teams are supported and set up for success to migrate all remaining components prior to CoffeeScript support being removed.
+The trimester deliverables will be developing and delivering at least eight migrated components.
+However, the long-term project deliverables are to ensure all future teams are supported and set up
+for success to migrate all remaining components prior to CoffeeScript support being removed.
 
-The functionality of the migrated components will be identical to the old ones, with a user interface design that fits in with the new OnTrack theme. Testing of these components must also be considered and implemented to ensure that the components will function as expected for students and faculty.
+The functionality of the migrated components will be identical to the old ones, with a user
+interface design that fits in with the new OnTrack theme. Testing of these components must also be
+considered and implemented to ensure that the components will function as expected for students and
+faculty.
 
 #### _Project Members (18)_
 
@@ -263,29 +334,53 @@ Team 8: Zheng Jiahao, Huang Yongqi
 
 #### *Overview, Goals, and Objectives* 
 
-The Deployment project aim is to create an employee-run deployment of OnTrack separated from the existing Deakin version and hosted on Google Cloud. Due to the scale of the project, there are three subgroups within the project which will focus on Google Cloud deployment, CI/CD pipeline, and enhanced authentication. The objective of the Thoth Tech hosted version of OnTrack is to allow the company to own the deployment cadence, conduct end-to-end testing, reduce risks leaking bugs upstream an innovate on new features. In addition, stakeholders will have a much more efficient setup, as well an improved process for future employees contributing to the project. The pipeline will be focused on improving software delivery with a CI/CD approach to speed up development and provide a level of quality assurance, whilst the authentication system will ensure security and privacy.
+The Deployment project aim is to create an employee-run deployment of OnTrack separated from the
+existing Deakin version and hosted on Google Cloud. Due to the scale of the project, there are three
+subgroups within the project which will focus on Google Cloud deployment, CI/CD pipeline, and
+enhanced authentication. The objective of the Thoth Tech hosted version of OnTrack is to allow the
+company to own the deployment cadence, conduct end-to-end testing, reduce risks leaking bugs
+upstream an innovate on new features. In addition, stakeholders will have a much more efficient
+setup, as well an improved process for future employees contributing to the project. The pipeline
+will be focused on improving software delivery with a CI/CD approach to speed up development and
+provide a level of quality assurance, whilst the authentication system will ensure security and
+privacy.
 
 #### *Aims for Trimester* 
 
-- Deploy a student-run version of OnTrack hosted on Google Cloud. This version will be running in isolation, independently of the Deakin University version.
-- Create a CI/CD pipeline that automates the building, deployment, and validation of a of the Thoth Tech OnTrack to Google Cloud.
-- Enable an enhanced authentication for user login which securely transmits data and protects stakeholder privacy.
+- Deploy a student-run version of OnTrack hosted on Google Cloud. This version will be running in
+  isolation, independently of the Deakin University version.
+- Create a CI/CD pipeline that automates the building, deployment, and validation of a of the Thoth
+  Tech OnTrack to Google Cloud.
+- Enable an enhanced authentication for user login which securely transmits data and protects
+  stakeholder privacy.
 
 #### *Deliverables* 
 
 ##### **Google Cloud**
 
-Short term deliverables will be to Design and document the architecture overview and overall deployment, work collaboratively with relevant teams to automate the build, test, and deployment of OnTrack using a CI/CD pipeline, work collaboratively with relevant teams to allow for secure authentication for users of OnTrack and build a secure platform for the OnTrack deployment to be hosted on Google Cloud
+Short term deliverables will be to Design and document the architecture overview and overall
+deployment, work collaboratively with relevant teams to automate the build, test, and deployment of
+OnTrack using a CI/CD pipeline, work collaboratively with relevant teams to allow for secure
+authentication for users of OnTrack and build a secure platform for the OnTrack deployment to be
+hosted on Google Cloud
 
-Long term deliverables will be to host multiple environments (such as Production, Development, and potentially Test/Staging) of the OnTrack deployment in Google Cloud, as well as review further expansion to run multi-tenanted environments for Deakin University and other organisations within Google Cloud.
+Long term deliverables will be to host multiple environments (such as Production, Development, and
+potentially Test/Staging) of the OnTrack deployment in Google Cloud, as well as review further
+expansion to run multi-tenanted environments for Deakin University and other organisations within
+Google Cloud.
 
 ##### **Pipeline**
 
-The short-term deliverable is that there will be an automated build CI/CD pipeline in production building and deploying OnTrack on to the Google Cloud platform and ensuring it is documented for long term usage and maintenance.
+The short-term deliverable is that there will be an automated build CI/CD pipeline in production
+building and deploying OnTrack on to the Google Cloud platform and ensuring it is documented for
+long term usage and maintenance.
 
 ##### **Enhance Authentication**
 
-Short term deliverables will be focusing on the empathise, define, and ideate stages - by giving more time to designing the possible solution, the team can produce a better answer. When the blueprint is out, the team will use the rest of the time to work on making the prototypes. Creating LDAP (Lightweight Directory Access Protocol) servers and testing them.
+Short term deliverables will be focusing on the empathise, define, and ideate stages - by giving
+more time to designing the possible solution, the team can produce a better answer. When the
+blueprint is out, the team will use the rest of the time to work on making the prototypes. Creating
+LDAP (Lightweight Directory Access Protocol) servers and testing them.
 
 Long term deliverables will be continuous maintenance, improvement, and testing of the solution.
 
@@ -300,27 +395,39 @@ Long term deliverables will be continuous maintenance, improvement, and testing 
 
 #### _Overview, Goals, and Objectives_
 
-In the current version of the OnTrack product there is no support for submitting Jupyter Notebook ‘.ipynb’ files directly to OnTrack. As a result of this limitation, student users must export their Jupyter Notebook file as an HTML document, and then use a PDF converter to create a PDF suitable for uploading to OnTrack. This results in an inefficient, poor, and frustrating user experience.
+In the current version of the OnTrack product there is no support for submitting Jupyter Notebook
+‘.ipynb’ files directly to OnTrack. As a result of this limitation, student users must export their
+Jupyter Notebook file as an HTML document, and then use a PDF converter to create a PDF suitable for
+uploading to OnTrack. This results in an inefficient, poor, and frustrating user experience.
 
-The goal of this project is to solve this issue by allowing students to upload .ipynb files directly to OnTrack and utilise OnTrack’s PDF conversion pipeline to handle automatically converting the file to PDF format for the faculty staff to view.
+The goal of this project is to solve this issue by allowing students to upload .ipynb files directly
+to OnTrack and utilise OnTrack’s PDF conversion pipeline to handle automatically converting the file
+to PDF format for the faculty staff to view.
 
-The objective of this project is to help make using OnTrack a more efficient process and improve ease of use for students and staff involved in tasks that use Jupyter Notebook.
+The objective of this project is to help make using OnTrack a more efficient process and improve
+ease of use for students and staff involved in tasks that use Jupyter Notebook.
 
 #### _Aims for Trimester_
 
-For this trimester the Jupyter Notebook Support project team will review the existing work on this feature and create a plan to fully deliver the Jupyter Notebook file to PDF conversion feature.
+For this trimester the Jupyter Notebook Support project team will review the existing work on this
+feature and create a plan to fully deliver the Jupyter Notebook file to PDF conversion feature.
 
 #### _Deliverables_
 
-The deliverables for this project will be the introduction of PDF conversion functionality for ‘.ipynb’ files into OnTrack, as well as documentation on the feature and a user guide on how to utilise the feature.
+The deliverables for this project will be the introduction of PDF conversion functionality for
+‘.ipynb’ files into OnTrack, as well as documentation on the feature and a user guide on how to
+utilise the feature.
 
 - Give OnTrack the ability to accept ‘.ipynb’ files directly.
 - Have fully functioning ‘.ipynb’ to PDF conversion support integrated to Ontrack.
-- Have a proper user guide documentation for anyone to follow and get familiar with the implemented feature.
+- Have a proper user guide documentation for anyone to follow and get familiar with the implemented
+  feature.
 - Keep track of how often the feature is being used as well as any failed conversions in a log.
-- To make sure that the code the team write for this feature does not affect any existing features or dependencies.
+- To make sure that the code the team write for this feature does not affect any existing features
+  or dependencies.
 
-Long term deliverables beyond this trimester will be the maintenance and improvement of this feature.
+Long term deliverables beyond this trimester will be the maintenance and improvement of this
+feature.
 
 #### _Project Members (5)_
 
@@ -340,24 +447,35 @@ Ethan G. Keirs
 
 #### _Overview, Goals, and Objectives_
 
-Currently, the OnTrack product has the functionality to accept audio submissions, but no verification system. Voice Verification for the online audio submissions will help mitigate cheating attempts and plagiarism.
+Currently, the OnTrack product has the functionality to accept audio submissions, but no
+verification system. Voice Verification for the online audio submissions will help mitigate cheating
+attempts and plagiarism.
 
-In the past there have been teams who have worked on a Speaker Verification Library to validate audio files, a Speaker Verification API to wrap the library, and a Ruby app to integrate Doubtfire LMS and the Speaker Verification API. The objective of this project is to finalise a proof of concept for the Voice Verification system, deploy it to the Thoth Tech OnTrack environment, and deliver technical documentation.
+In the past there have been teams who have worked on a Speaker Verification Library to validate
+audio files, a Speaker Verification API to wrap the library, and a Ruby app to integrate Doubtfire
+LMS and the Speaker Verification API. The objective of this project is to finalise a proof of
+concept for the Voice Verification system, deploy it to the Thoth Tech OnTrack environment, and
+deliver technical documentation.
 
 #### *Aims for Trimester* 
 
-The aim for this trimester is to work on understanding the work completed by previous teams, finish the voice verification feature, test the functionality, and create accurate documentation for the entirety of the Voice Verification system; architecture, deployment and how to user it.
+The aim for this trimester is to work on understanding the work completed by previous teams, finish
+the voice verification feature, test the functionality, and create accurate documentation for the
+entirety of the Voice Verification system; architecture, deployment and how to user it.
 
 #### *Deliverables* 
 
-The short-term deliverables for this project will be upskilling, understanding, improving, integrating, testing, deploying, and developing any gaps identified in the existing pieces of work completed for the Voice Verification feature. This includes:
+The short-term deliverables for this project will be upskilling, understanding, improving,
+integrating, testing, deploying, and developing any gaps identified in the existing pieces of work
+completed for the Voice Verification feature. This includes:
 
 - A Proof-of-Concept integration of Speaker Verification on Doubtfire.
 - Enrolment: Students can register their voice
 - Verification: When a task submission is received, verify the attached voice file
 - Deployed to the Thoth Tech OnTrack instance
 
-There will also be the deliverable of creating documentation to ensure that the architecture, deployment, and user guides for recording voice samples for enrolment and verification.
+There will also be the deliverable of creating documentation to ensure that the architecture,
+deployment, and user guides for recording voice samples for enrolment and verification.
 
 The long-term deliverables for this project will be maintenance and improvements of this feature.
 
@@ -381,9 +499,17 @@ Yanjun Chen
 
 #### _Overview_
 
-The Documentation project objective is to create documentation for the Thoth Tech company and its products, including OnTrack. The current state of documentation of Thoth Tech’s products’ is poor; with previous design decisions, updates and feature implementations not accurately documented or maintained. By clearly documenting the products Thoth Tech’s employees will be set up for success to hit the ground running when joining the company and a team. Additionally, the products’ end users, which include university students and educators, will find it easy to learn and use the products with simple and accessible documentation at hand.
+The Documentation project objective is to create documentation for the Thoth Tech company and its
+products, including OnTrack. The current state of documentation of Thoth Tech’s products’ is poor;
+with previous design decisions, updates and feature implementations not accurately documented or
+maintained. By clearly documenting the products Thoth Tech’s employees will be set up for success to
+hit the ground running when joining the company and a team. Additionally, the products’ end users,
+which include university students and educators, will find it easy to learn and use the products
+with simple and accessible documentation at hand.
 
-The objective of the team is to create a smooth onboarding process and simplify the process of creating and managing documentation across the Thoth Tech products, for all teams. Having good documentation for the future trimesters will result in higher productivity and increasing progress.
+The objective of the team is to create a smooth onboarding process and simplify the process of
+creating and managing documentation across the Thoth Tech products, for all teams. Having good
+documentation for the future trimesters will result in higher productivity and increasing progress.
 
 The goals of the documentation project are to:
 
@@ -395,13 +521,24 @@ The goals of the documentation project are to:
 
 #### _Aims for Trimester_
 
-The documentation team’s aim for the trimester is to ensure everything related to Thoth Tech is efficiently and accurately documented moving forward. By collating existing documentation, analysing gaps, collaborating with development teams’, and creating new documentation, the contributions made by the documentation team will set up future team leaders and members who decide to join Thoth Tech for success.
+The documentation team’s aim for the trimester is to ensure everything related to Thoth Tech is
+efficiently and accurately documented moving forward. By collating existing documentation, analysing
+gaps, collaborating with development teams’, and creating new documentation, the contributions made
+by the documentation team will set up future team leaders and members who decide to join Thoth Tech
+for success.
 
 #### _Deliverables_
 
-The first short-term deliverable for this project is to establish documentation guidelines and processes for all teams within the company to create and organise documentation for use, operation, maintenance, design, test, and access. This will ensure accountability and compliance to documentation standards and that documentation is highly accessible. The second deliverable for this project is to analyse the Ontrack repository for relevant documentation that needs to be updated, improved, or created if none exists already. This includes design documentation, requirement documentation, user documentation for development and user guides.
+The first short-term deliverable for this project is to establish documentation guidelines and
+processes for all teams within the company to create and organise documentation for use, operation,
+maintenance, design, test, and access. This will ensure accountability and compliance to
+documentation standards and that documentation is highly accessible. The second deliverable for this
+project is to analyse the Ontrack repository for relevant documentation that needs to be updated,
+improved, or created if none exists already. This includes design documentation, requirement
+documentation, user documentation for development and user guides.
 
-The long-term deliverables are to ensure that all documentation is kept up to date with changes made to the products, and to perform the same analysis and work on the SplashKit product.
+The long-term deliverables are to ensure that all documentation is kept up to date with changes made
+to the products, and to perform the same analysis and work on the SplashKit product.
 
 #### _Project Members (7)_
 
@@ -423,7 +560,18 @@ Shivam Singh
 
 ## SplashKit
 
-SplashKit is an open-source Software Development Kit (SDK)​, created with the purpose of reducing the overhead required for truly technical coding​ and allowing students new to coding to create satisfying programs in a short period of time. SplashKit enables beginning coders to quickly learn to construct fun and functional programs which they can be proud to showcase. SplashKit is an open-source Software Development Kit (SDK)​, created with the purpose of reducing the overhead required for truly technical coding​ which enables students new to coding to create satisfying programs in a short period of time. SplashKit enables novice coders to quickly learn to construct fun and functional programs which they can be proud to showcase. It includes a large library of functions which can be utilized by the user to experiment and apply for their own application or game. This product is currently used by the students at Deakin University and aims to become a global educational toolkit. Currently the language used for development is C++ and the direction of the product is to improve and expand the capabilities to increase SplashKit accessibility.
+SplashKit is an open-source Software Development Kit (SDK)​, created with the purpose of reducing
+the overhead required for truly technical coding​ and allowing students new to coding to create
+satisfying programs in a short period of time. SplashKit enables beginning coders to quickly learn
+to construct fun and functional programs which they can be proud to showcase. SplashKit is an
+open-source Software Development Kit (SDK)​, created with the purpose of reducing the overhead
+required for truly technical coding​ which enables students new to coding to create satisfying
+programs in a short period of time. SplashKit enables novice coders to quickly learn to construct
+fun and functional programs which they can be proud to showcase. It includes a large library of
+functions which can be utilized by the user to experiment and apply for their own application or
+game. This product is currently used by the students at Deakin University and aims to become a
+global educational toolkit. Currently the language used for development is C++ and the direction of
+the product is to improve and expand the capabilities to increase SplashKit accessibility.
 
 **Product Lead:** Yash Kondlekar
 
@@ -431,14 +579,21 @@ SplashKit is an open-source Software Development Kit (SDK)​, created with the
 
 #### *Overview, Goals, and Objectives* 
 
-The Programming Arcana is an open-source friendly programming textbook that teaches introductory programming concepts to those new to programming. From the programming Arcana’s GitHub, the guiding principles are:
+The Programming Arcana is an open-source friendly programming textbook that teaches introductory
+programming concepts to those new to programming. From the programming Arcana’s GitHub, the guiding
+principles are:
 
 - Transferable concepts are more important than language specifics
 - Build concepts on top of known concepts as much as possible
 - Focus on procedural programming initially, with a view to transitioning to objects
 - Build programs that make it easy to see what is happening in the code
 
-The programming Arcana currently has two versions, 1.0.x and 2.0.x. Version 1.0.x uses Tex as its typesetting system. Version 2.0.x uses Markdown as its typesetting system. This version also uses NodeJS and React to deploy a website. Version 2.0.x is still in progress; therefore, goals include finishing the documents, creating different programming language examples, and migrating the programming Arcana into SplashKit which would allow the SplashKit users to view the programming Arcana as they are developing resulting in an enhanced learning experience.
+The programming Arcana currently has two versions, 1.0.x and 2.0.x. Version 1.0.x uses Tex as its
+typesetting system. Version 2.0.x uses Markdown as its typesetting system. This version also uses
+NodeJS and React to deploy a website. Version 2.0.x is still in progress; therefore, goals include
+finishing the documents, creating different programming language examples, and migrating the
+programming Arcana into SplashKit which would allow the SplashKit users to view the programming
+Arcana as they are developing resulting in an enhanced learning experience.
 
 #### *Aims for Trimester* 
 
@@ -474,24 +629,38 @@ Long-term:
 
 #### *Overview, Goals, and Objectives* 
 
-SplashKit is a product that has been developed to abstract away the complexities of programming languages for novice programmers. However, the toolchains and development environments required to use SplashKit can be difficult and confusing to see tup for inexperienced users. Some aspects of these issues have already been eased using SplashKit’s current install script, but it’s been observed that the initial installation process for “skm" could be further simplified.
+SplashKit is a product that has been developed to abstract away the complexities of programming
+languages for novice programmers. However, the toolchains and development environments required to
+use SplashKit can be difficult and confusing to see tup for inexperienced users. Some aspects of
+these issues have already been eased using SplashKit’s current install script, but it’s been
+observed that the initial installation process for “skm" could be further simplified.
 
-The Distribution Channel Team intends to improve the installation process of SplashKit for new users across all three major operating systems; Windows, Linux and macOS.
+The Distribution Channel Team intends to improve the installation process of SplashKit for new users
+across all three major operating systems; Windows, Linux and macOS.
 
-The result of these improvements aims to be a single command or executable installation process that yields a working development environment for SplashKit on Windows, Linux or macOS ready for the user to start using SplashKit as quickly as possible. Decreasing the friction of the installation process aims to streamline the setup process for new users, potentially adding both product value to SplashKit – and confidence to new users.
+The result of these improvements aims to be a single command or executable installation process that
+yields a working development environment for SplashKit on Windows, Linux or macOS ready for the user
+to start using SplashKit as quickly as possible. Decreasing the friction of the installation process
+aims to streamline the setup process for new users, potentially adding both product value to
+SplashKit – and confidence to new users.
 
 #### *Aims for Trimester* 
 
 The main aims for the Distribution Channel Team this trimester:
 
-- Research the existing installation process, the SplashKit management tool “skm”, and possible methods of improved installation on all three major operating systems.
-- Research and report on current known issues with respect to the installation of SplashKit on all three major operating systems.
+- Research the existing installation process, the SplashKit management tool “skm”, and possible
+  methods of improved installation on all three major operating systems.
+- Research and report on current known issues with respect to the installation of SplashKit on all
+  three major operating systems.
 - Report on future possibilities
 - Investigate issues with Mac M1 chip devices
 
 #### *Deliverables* 
 
-Currently the deliverables planned for Sprint 1 will be to investigate the user and customer requirements in installing splash kit on Linux, Windows, and Mac OS (including the recent M1 chip). These deliverables are critical to the scoping of future deliverables and direction for our team as once completed, potential solutions can be determined, and tasks delegated accordingly.
+Currently the deliverables planned for Sprint 1 will be to investigate the user and customer
+requirements in installing splash kit on Linux, Windows, and Mac OS (including the recent M1 chip).
+These deliverables are critical to the scoping of future deliverables and direction for our team as
+once completed, potential solutions can be determined, and tasks delegated accordingly.
 
 The current deliverables intended for completion prior to the conclusion of sprint 1 are as follows:
 
@@ -504,7 +673,8 @@ The current deliverables intended for completion prior to the conclusion of spri
   - Could containerisation containing all dependencies be streamlined enough for users?
   - Can the dependencies be installed in one downloadable bash/PowerShell script?
 
-Our expectation is that the information gathered will to turn these into long-term deliverables and break those down into deliverables for the upcoming Sprint 2 and 3.
+Our expectation is that the information gathered will to turn these into long-term deliverables and
+break those down into deliverables for the upcoming Sprint 2 and 3.
 
 #### _Project Members (4)_
 
@@ -517,14 +687,20 @@ Our expectation is that the information gathered will to turn these into long-te
 
 #### *Overview, Goals, and Objectives* 
 
-The SplashKit translator is a Ruby application that translates the original cpp library into a target language. Currently, the translator enables translation of the SplashKit library into Python (< 3.8), Pascal, Rust, and C#. The SplashKit Extensions project’s aim is to provide the SplashKit library interface in additional languages.
+The SplashKit translator is a Ruby application that translates the original cpp library into a
+target language. Currently, the translator enables translation of the SplashKit library into Python
+(< 3.8), Pascal, Rust, and C#. The SplashKit Extensions project’s aim is to provide the SplashKit
+library interface in additional languages.
 
-Translating the SplashKit library into other languages provides the flexibility to teach other languages using SplashKit as well as increase the adoption of SplashKit. The project also ensures SplashKit’s continued relevance in a changing field.
+Translating the SplashKit library into other languages provides the flexibility to teach other
+languages using SplashKit as well as increase the adoption of SplashKit. The project also ensures
+SplashKit’s continued relevance in a changing field.
 
 #### *Aims for Trimester* 
 
 - Understand how the language translators works
-- Investigate changes in Python between 3.8x versions and earlier to identify which of these changes have caused current incompatibilities.
+- Investigate changes in Python between 3.8x versions and earlier to identify which of these changes
+  have caused current incompatibilities.
 - Get SplashKit successfully working on the latest Python version (3.10.x).
 - Develop a new language translation for the Translator.
 - Test all existing and new language translations.
@@ -534,12 +710,15 @@ Translating the SplashKit library into other languages provides the flexibility 
 
 Short-term:
 
-- Documentation of the installation/setup of the SplashKit translator for development (Windows/Linux).
+- Documentation of the installation/setup of the SplashKit translator for
+  development (Windows/Linux).
 - Documentation of the installation/setup and operation of the SplashKit translator.
 - Documentation of the process to test each of the language translations.
 - At least 1 working language extension for SplashKit.
-- SplashKit translated into Python compatible with version 3.10.x and backwards compatible (if possible).
-- Project decisions documentation to provide evidence-based decision-making history for future teams.
+- SplashKit translated into Python compatible with version 3.10.x and backwards compatible (if
+  possible).
+- Project decisions documentation to provide evidence-based decision-making history for future
+  teams.
 
 Long-term:
 
@@ -556,17 +735,23 @@ Long-term:
 
 #### *Overview, Goals, and Objectives* 
 
-The goal of this project is to create a physical arcade machine with accompanying software to showcase student games, developed with the [SplashKit](https://splashkit.io/) SDK. The machine will perform similarly to a Multi-Game Arcade Machine, allowing users to select a game from a local library of games. Our system ideally will instead have access to a growing library of SplashKit games publicly hosted on the internet. Objectives include:
+The goal of this project is to create a physical arcade machine with accompanying software to
+showcase student games, developed with the [SplashKit](https://splashkit.io/) SDK. The machine will
+perform similarly to a Multi-Game Arcade Machine, allowing users to select a game from a local
+library of games. Our system ideally will instead have access to a growing library of SplashKit
+games publicly hosted on the internet. Objectives include:
 
 - Software which supports the ability to:
   - Upload games to the Arcade Machine
   - Select and play games on the Arcade Machine
 - The development of:
-  - A vetting process which validates and reviews games for explicit/unacceptable content before addition
+  - A vetting process which validates and reviews games for explicit/unacceptable content before
+    addition
   - A user guide walking through the process of uploading games to the system.
   - Documentation
 
-Additional features which may be considered later in the lifecycle of the project include the development and deployment of a website which:
+Additional features which may be considered later in the lifecycle of the project include the
+development and deployment of a website which:
 
 - Supports the uploading of games
 - Stores and displays:
@@ -575,14 +760,20 @@ Additional features which may be considered later in the lifecycle of the projec
 
 #### *Aims for Trimester* 
 
-The primary aim of this trimester is to develop a platform which supports the uploading, storage, and access to a growing library of games developed using the SplashKit SDK. Access to the game library will be offered through the platform where the user can configure settings and select and play their desired game. If time permits, a physical Arcade Machine will be designed and manufactured however the software platform is the primary focus for the trimester.
+The primary aim of this trimester is to develop a platform which supports the uploading, storage,
+and access to a growing library of games developed using the SplashKit SDK. Access to the game
+library will be offered through the platform where the user can configure settings and select and
+play their desired game. If time permits, a physical Arcade Machine will be designed and
+manufactured however the software platform is the primary focus for the trimester.
 
 #### *Deliverables* 
 
 Short-term:
 
-- Platform which can access, download, and play SplashKit games stored in a public library on the internet.
-- Production of a physical Arcade Machine which runs on the platform to showcase SplashKit games created by students during university open days.
+- Platform which can access, download, and play SplashKit games stored in a public library on the
+  internet.
+- Production of a physical Arcade Machine which runs on the platform to showcase SplashKit games
+  created by students during university open days.
 
 Long-term:
 
@@ -606,17 +797,24 @@ Sarah Gosling
 
 #### _Overview, Goals, and Objectives_
 
-The project that the Build a Cool Game team has is to make games that can be showcased and played on the Arcade machine that is going to be virtually built. The goal is to make a game that uses all functions that SplashKit has to offer within game creation. The long-term goal will showcase that SplashKit can be extended upon as a game engine and can create games that can be played on different platforms. As SplashKit is widely used to create 2D games, it will be a good opportunity to showcase how SplashKit games can be extended and shown on a physical arcade machine.
+The project that the Build a Cool Game team has is to make games that can be showcased and played on
+the Arcade machine that is going to be virtually built. The goal is to make a game that uses all
+functions that SplashKit has to offer within game creation. The long-term goal will showcase that
+SplashKit can be extended upon as a game engine and can create games that can be played on different
+platforms. As SplashKit is widely used to create 2D games, it will be a good opportunity to showcase
+how SplashKit games can be extended and shown on a physical arcade machine.
 
 #### *Aims for Trimester* 
 
-The aim for this trimester is to work on game creation using SplashKit. This must incorporate all the functions that SplashKit has to make the games. This will showcase the creation tools that game developers can use to create a game from scratch so that it can be played on the arcade machine.
+The aim for this trimester is to work on game creation using SplashKit. This must incorporate all
+the functions that SplashKit has to make the games. This will showcase the creation tools that game
+developers can use to create a game from scratch so that it can be played on the arcade machine.
 
-*Deliverables* 
-Short-term:
+*Deliverables*  Short-term:
 
 - Cool 2D games demonstrating all functionality of SplashKit. (Minimum 1 per team member)
-- A step-by-step article guide of How to create the Cool games produced (Document design decisions, process and how-to-guides)
+- A step-by-step article guide of How to create the Cool games produced (Document design decisions,
+  process and how-to-guides)
 - Guide uploaded to the SplashKit.io website.
 
 Long-term:
@@ -640,15 +838,31 @@ Bella Chhour
 
 #### Overview, Goals, and Objectives 
 
-Across three modules, Physics, Data Analytics and Machine Learning, SplashKit aims to enrich and expand its functionality, to improve current features and extend its user base beyond game development. In the next two years, SplashKit aims to develop a full 2D physics engine that can be used by game developers, requiring the addition of a realistic and easy to use physics library. New capabilities to interact with, visualise, and analyse data are aiming to attract new users and provide data analytics functionalities for the existing user base.
+Across three modules, Physics, Data Analytics and Machine Learning, SplashKit aims to enrich and
+expand its functionality, to improve current features and extend its user base beyond game
+development. In the next two years, SplashKit aims to develop a full 2D physics engine that can be
+used by game developers, requiring the addition of a realistic and easy to use physics library. New
+capabilities to interact with, visualise, and analyse data are aiming to attract new users and
+provide data analytics functionalities for the existing user base.
 
-SplashKit’s current objective for Machine Learning is to develop an Artificial Intelligence framework that allows the inclusion of artificial co-op or opposition characters into SplashKit games, with a long-term goal to integrate with the Data Analytics module and to create a complete Machine Learning framework.
+SplashKit’s current objective for Machine Learning is to develop an Artificial Intelligence
+framework that allows the inclusion of artificial co-op or opposition characters into SplashKit
+games, with a long-term goal to integrate with the Data Analytics module and to create a complete
+Machine Learning framework.
 
 #### *Aims for Trimester* 
 
-This trimester, the team are aiming to finalise and publish the existing work completed for all three modules. The Physics and Data Analytics team are aiming to review and publish the existing elastic collision, impulse effect, and data frame code from past developers, whilst the Machine Learning team is expecting to use the example code from past developers as reference to build a brand-new system.
+This trimester, the team are aiming to finalise and publish the existing work completed for all
+three modules. The Physics and Data Analytics team are aiming to review and publish the existing
+elastic collision, impulse effect, and data frame code from past developers, whilst the Machine
+Learning team is expecting to use the example code from past developers as reference to build a
+brand-new system.
 
-The team aims to produce new functionality this trimester to the existing code, including extending the physics API to complete the handing of 2D sprite and object collisions, and implementing gravity. Data Analytics team plan to extend data frames to allow instance selection, standardisation, transformation, and feature selection. Machine Learning team aims to design a reinforcement learning algorithm that is capable of co-op or opposition AI in SplashKit games.
+The team aims to produce new functionality this trimester to the existing code, including extending
+the physics API to complete the handing of 2D sprite and object collisions, and implementing
+gravity. Data Analytics team plan to extend data frames to allow instance selection,
+standardisation, transformation, and feature selection. Machine Learning team aims to design a
+reinforcement learning algorithm that is capable of co-op or opposition AI in SplashKit games.
 
 #### *Deliverables* 
 
@@ -658,11 +872,14 @@ Short term:
 - Verified existing code documented and pushed to SplashKit repository.
 - New feature documentation (user guides)
 - Physics:
-  - Physics artefact enhancing collisions between sprites and objects, and gravity that acts on them.
+  - Physics artefact enhancing collisions between sprites and objects, and gravity that acts on
+    them.
 - Data Analytics:
-  - Deliver new code that enables instance selection, standardisation, transformation, and feature selection on the existing Data Frames.
+  - Deliver new code that enables instance selection, standardisation, transformation, and feature
+    selection on the existing Data Frames.
 - Machine Learning:
-  - Design and prototype a reinforcement learning algorithm, providing evidence of research and design, that will be capable of training co-op and villain characters in SplashKit games.
+  - Design and prototype a reinforcement learning algorithm, providing evidence of research and
+    design, that will be capable of training co-op and villain characters in SplashKit games.
 
 Long term:
 
@@ -671,7 +888,8 @@ Long term:
 - Implementing new features
   - Implement sinking objects and projectile motion (Physics team)
   - Implement visual plotting and statistics (Data Analytics team)
-  - Implement function approximation to the designed reinforcement learning algorithm (Machine Learning team)
+  - Implement function approximation to the designed reinforcement learning algorithm (Machine
+    Learning team)
 
 #### _Project Members (8)_
 
@@ -682,7 +900,12 @@ Long term:
 
 ## DreamBig
 
-DreamBig is a new product innovation driven by the School of IT at Deakin. DreamBig aims to provide a personalised roadmap integrated with Ontrack to support students to develop their professional identity across their course and improve their employability after graduation. In addition, it aims to provide a platform to help set realistic expectations for students graduating into the real world. In line with this vision, it is proposed to build a prototype that can help achieve the following goals:
+DreamBig is a new product innovation driven by the School of IT at Deakin. DreamBig aims to provide
+a personalised roadmap integrated with Ontrack to support students to develop their professional
+identity across their course and improve their employability after graduation. In addition, it aims
+to provide a platform to help set realistic expectations for students graduating into the real
+world. In line with this vision, it is proposed to build a prototype that can help achieve the
+following goals:
 
 - Multi-dimensional visualisation of each student's growing professional identity
 - Used within curriculum to encourage engagement.
@@ -696,11 +919,16 @@ DreamBig is a new product innovation driven by the School of IT at Deakin. Dre
 
 #### *Overview, Goals, and Objectives* 
 
-DreamBig is at its early inception. The customer needs and product requirements are still yet discovered and refined. The Prototype project is an attempt to explore the product-market fit. The process includes determining our target customer, identifying underserved customer needs, defining the product value proposition, specifying the MVP feature set, building, and testing the prototype with the customers.
+DreamBig is at its early inception. The customer needs and product requirements are still yet
+discovered and refined. The Prototype project is an attempt to explore the product-market fit. The
+process includes determining our target customer, identifying underserved customer needs, defining
+the product value proposition, specifying the MVP feature set, building, and testing the prototype
+with the customers.
 
 #### _Aims for Trimester_
 
-Research will be conducted to investigate customer needs and prioritise high-value features. These will form the minimum viable product (MVP). As part of this work, the following will be established:
+Research will be conducted to investigate customer needs and prioritise high-value features. These
+will form the minimum viable product (MVP). As part of this work, the following will be established:
 
 - High-level UX and UI approach
 - Documentation of user flows
@@ -730,7 +958,10 @@ Long-term:
 
 ## Internal Systems
 
-The internal systems product is a new initiative driven mitigating the challenge of the Thoth Tech company turning over half its employees every four months. The aim of this is to provide an accessible centralized location to display key company information and documentation which is sourced from the Thoth Tech repo.
+The internal systems product is a new initiative driven mitigating the challenge of the Thoth Tech
+company turning over half its employees every four months. The aim of this is to provide an
+accessible centralized location to display key company information and documentation which is
+sourced from the Thoth Tech repo.
 
 **Product Lead:** Abigail Howe
 
@@ -738,15 +969,24 @@ The internal systems product is a new initiative driven mitigating the challenge
 
 #### *Overview, Goals, and Objectives* 
 
-The goal for the Internal systems team is to research, scope, plan and prototype a web page that will house all necessary information for Thoth Tech. To achieve this the main objectives across the Internal Systems team will be to research different tools, technologies and processes and decide on what will best serve requirements and given team member skills whilst also allowing for expansion and adaptability in the future. The web page will create a centralised location for all the company’s information needed for its internal audience. This in turn will simplify the onboarding and resource sharing amongst the company and its everchanging audiences.
+The goal for the Internal systems team is to research, scope, plan and prototype a web page that
+will house all necessary information for Thoth Tech. To achieve this the main objectives across the
+Internal Systems team will be to research different tools, technologies and processes and decide on
+what will best serve requirements and given team member skills whilst also allowing for expansion
+and adaptability in the future. The web page will create a centralised location for all the
+company’s information needed for its internal audience. This in turn will simplify the onboarding
+and resource sharing amongst the company and its everchanging audiences.
 
 #### *Aims for Trimester* 
 
-The aim this trimester is to plan out the architecture needed, design the page, and create documentation that will serve as a solid base for the progressive development of the web page.
+The aim this trimester is to plan out the architecture needed, design the page, and create
+documentation that will serve as a solid base for the progressive development of the web page.
 
-An understanding will be built of components required and the privacy and privileges needed by different users. A prototype will also be built that will showcase the design and functionality.
+An understanding will be built of components required and the privacy and privileges needed by
+different users. A prototype will also be built that will showcase the design and functionality.
 
-Git will be used to manage team contributions to the development of the web page and guidelines will be created for the testing structure utilised.
+Git will be used to manage team contributions to the development of the web page and guidelines will
+be created for the testing structure utilised.
 
 #### Deliverables
 

--- a/docs/company/reports/t1-2022/company-report-v2.md
+++ b/docs/company/reports/t1-2022/company-report-v2.md
@@ -6,17 +6,41 @@
 
 ## Executive Summary
 
-Thoth Tech (est. 2022) is a new software development company currently building from the ground up in Melbourne Australia. Thoth Tech’s mission is to build, operate, and deploy education technologies, creating tools that enhance education outcomes by empowering students, connecting them with tutors, and facilitating personalised learning experiences. We value our people, and we value excellence: We are people-focused, aim to produce sustainable products of excellent quality, and provide frameworks that provide a safe environment for learning and support of our team.
+Thoth Tech (est. 2022) is a new software development company currently building from the ground up
+in Melbourne Australia. Thoth Tech’s mission is to build, operate, and deploy education
+technologies, creating tools that enhance education outcomes by empowering students, connecting them
+with tutors, and facilitating personalised learning experiences. We value our people, and we value
+excellence: We are people-focused, aim to produce sustainable products of excellent quality, and
+provide frameworks that provide a safe environment for learning and support of our team.
 
-This report is for stakeholders, investors, and employees, and will outline the company structure, charter, objectives – both short and long term, and explore each product’s goals in depth.
+This report is for stakeholders, investors, and employees, and will outline the company structure,
+charter, objectives – both short and long term, and explore each product’s goals in depth.
 
-Within the first third of 2022, Thoth Tech has recruited approximately 92 employees including four area leads, three product leads and eleven delivery leads. There will be another recruitment phase during the other two thirds of the year and an expected exit rate of 50 percent, with the potential for internships throughout the company.
+Within the first third of 2022, Thoth Tech has recruited approximately 92 employees including four
+area leads, three product leads and eleven delivery leads. There will be another recruitment phase
+during the other two thirds of the year and an expected exit rate of 50 percent, with the potential
+for internships throughout the company.
 
-Along with recruitment, Thoth Tech has taken onboard three external products, two live and well-established products – _OnTrack_ and _SplashKit_ – and _DreamBig_, a in development product which will leverage the OnTrack technology stack. Thoth Tech will also be creating our internal architecture and platform for employees throughout this third of the year, referred to as the _Internal System_ project.
+Along with recruitment, Thoth Tech has taken onboard three external products, two live and
+well-established products – _OnTrack_ and _SplashKit_ – and _DreamBig_, a in development product
+which will leverage the OnTrack technology stack. Thoth Tech will also be creating our internal
+architecture and platform for employees throughout this third of the year, referred to as the
+_Internal System_ project.
 
-Both the OnTrack and SplashKit products have been identified as requiring extensions and additional features to improve the quality and usability of the product. OnTrack is a platform designed to facilitate student learning and reducing the pressure of achieving unrealistic grades. The focus is on providing a tailored learning experience, using tasks and a portfolio assessment. This product is live and is currently being upgraded to newer technology stacks and improving security and documentation. SplashKit is currently a 2D game development Software Development Kit used to teach object-oriented coding to beginners. It has been identified that SplashKit can be expanded to explore other areas and languages. The DreamBig product is in response to a need identified by Deakin, to provide a personalised development roadmaps to enhance students’ employability.
+Both the OnTrack and SplashKit products have been identified as requiring extensions and additional
+features to improve the quality and usability of the product. OnTrack is a platform designed to
+facilitate student learning and reducing the pressure of achieving unrealistic grades. The focus is
+on providing a tailored learning experience, using tasks and a portfolio assessment. This product is
+live and is currently being upgraded to newer technology stacks and improving security and
+documentation. SplashKit is currently a 2D game development Software Development Kit used to teach
+object-oriented coding to beginners. It has been identified that SplashKit can be expanded to
+explore other areas and languages. The DreamBig product is in response to a need identified by
+Deakin, to provide a personalised development roadmaps to enhance students’ employability.
 
-Due to a partnership with the School of IT at Deakin University, Thoth Tech and the subsequent products are funded, supported, and leveraged by Deakin. However, all contributions by Thoth Tech members are acknowledged due to the Open-Source nature of the company. Deakin provides ground zero end-user testing and focus groups for product improvements.
+Due to a partnership with the School of IT at Deakin University, Thoth Tech and the subsequent
+products are funded, supported, and leveraged by Deakin. However, all contributions by Thoth Tech
+members are acknowledged due to the Open-Source nature of the company. Deakin provides ground zero
+end-user testing and focus groups for product improvements.
 
 \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
 
@@ -96,7 +120,8 @@ This trimester, Thoth Tech has set out to achieve the following objectives:
 - Establish a handover and Offboarding process.
 - Establish an internal website for centralised documentation visibility.
 
-**Objective 2: Create a safe, supportive, and collaborative company culture that empowers our employees to learn and develop their skills.**
+**Objective 2: Create a safe, supportive, and collaborative company culture that empowers our
+employees to learn and develop their skills.**
 
 - Create a company culture where feedback is welcome, and success is celebrated.
 - Support development of chosen skills in every team member.
@@ -121,18 +146,22 @@ This trimester, Thoth Tech has set out to achieve the following objectives:
 - Move Ontrack front-end away from legacy technologies.
 - Analyse, update, improve and create retrospective OnTrack documentation.
 
-**Objective 5: Create the DreamBig prototype as a new product that adds value to the Thoth Tech company**
+**Objective 5: Create the DreamBig prototype as a new product that adds value to the Thoth Tech
+company**
 
 - Build the vision and strategy for the DreamBig product.
 - Create a DreamBig prototype as proof of concept.
 
 ### The Area Lead Project
 
-The Area Lead Team is committed to delievering the company-wide Trimester Goals and Objectives, as stated above. This project has been in progress since Week 0, however, was not included within The Q1 Company Report
+The Area Lead Team is committed to delievering the company-wide Trimester Goals and Objectives, as
+stated above. This project has been in progress since Week 0, however, was not included within The
+Q1 Company Report
 
 #### _Aims for Trimester_
 
-The aim for the trimester is for each of the company-wide goals and objectives are completed or significantly progressed.
+The aim for the trimester is for each of the company-wide goals and objectives are completed or
+significantly progressed.
 
 #### _Deliverables_
 
@@ -171,7 +200,8 @@ Include a short description of the most important takeaways from your project st
 
 #### _Additional information and links_
 
-Link to relevant project details or higher-level project information that stakeholders might be curious about. May include links to relevant repositories, deliverables, SRS document, etc.
+Link to relevant project details or higher-level project information that stakeholders might be
+curious about. May include links to relevant repositories, deliverables, SRS document, etc.
 
 #### _Blockers_
 
@@ -189,7 +219,9 @@ Are there any additional things your team needs to know? What are the main next 
 
 # Company Charter
 
-The Thoth Tech charter is a crucial tool for guiding our team, navigating decisions, establishing boundaries, and aligning the team on how we work together. It defines how as a company we work together to achieve success.
+The Thoth Tech charter is a crucial tool for guiding our team, navigating decisions, establishing
+boundaries, and aligning the team on how we work together. It defines how as a company we work
+together to achieve success.
 
 Our charter comprises of the following:
 
@@ -202,23 +234,32 @@ Our charter comprises of the following:
 
 ## Mission
 
-Our mission is to build, operate and deploy world class education technologies. This is achieved by creating accessible tools that enhance education outcomes by empowering students, connecting them with tutors and facilitating personalised learning experiences.
+Our mission is to build, operate and deploy world class education technologies. This is achieved by
+creating accessible tools that enhance education outcomes by empowering students, connecting them
+with tutors and facilitating personalised learning experiences.
 
 ## Values
 
-Our values describe how we work, what we represent, and guide us to be the kind of company and team members we want to be. When we live up to these values we will:
+Our values describe how we work, what we represent, and guide us to be the kind of company and team
+members we want to be. When we live up to these values we will:
 
 **Be people-focused**
 
-We expect the best from each other, give each other the benefit of the doubt, encourage each other to take initiative to improve ourselves and the company, and provide direct and constructive help to each other. We collaborate with kindness while being respectful of each other.
+We expect the best from each other, give each other the benefit of the doubt, encourage each other
+to take initiative to improve ourselves and the company, and provide direct and constructive help to
+each other. We collaborate with kindness while being respectful of each other.
 
 **Uphold sustainable excellence**
 
-We create working, maintainable, and understandable software that is enjoyable and easy to use. We strive to do it in a way that is sustainable for our team members and for our environment.
+We create working, maintainable, and understandable software that is enjoyable and easy to use. We
+strive to do it in a way that is sustainable for our team members and for our environment.
 
 **Be inclusive and supportive**
 
-We celebrate diverse perspectives and embrace uncomfortable ideas and conversations. We facilitate an environment in which all team members feel psychologically safe enough to make requests for what they need to do their job. We learn through failures while continually working to make things better.
+We celebrate diverse perspectives and embrace uncomfortable ideas and conversations. We facilitate
+an environment in which all team members feel psychologically safe enough to make requests for what
+they need to do their job. We learn through failures while continually working to make things
+better.
 
 ## Team Culture
 
@@ -250,21 +291,35 @@ We celebrate diverse perspectives and embrace uncomfortable ideas and conversati
 
 # Company Structure
 
-The Company is broken up based on product, with the area leads spread company wide. There is a tier system built into the company structure – directors, area leads, product leads, delivery leads, then team members. This structure is primarily about support, guidance, and feedback, rather than authority.
+The Company is broken up based on product, with the area leads spread company wide. There is a tier
+system built into the company structure – directors, area leads, product leads, delivery leads, then
+team members. This structure is primarily about support, guidance, and feedback, rather than
+authority.
 
-Each employee has chosen their own role title based on their interests, skills, experience and what they want to develop.
+Each employee has chosen their own role title based on their interests, skills, experience and what
+they want to develop.
 
-The company structure is linked [here](https://deakin365.sharepoint.com/:b:/s/ThothTech2-Leadership/ERuLF9JWzz5HvF68OG7D_EgBQ14uMdrGKXuS2fvNEWE_WQ?e=ihX3Wt) and available on the next page.
+The company structure is linked
+[here](https://deakin365.sharepoint.com/:b:/s/ThothTech2-Leadership/ERuLF9JWzz5HvF68OG7D_EgBQ14uMdrGKXuS2fvNEWE_WQ?e=ihX3Wt)
+and available on the next page.
 
 # Product Overview
 
-Thoth Tech currently has two existing products, OnTrack and SplashKit, which are open source and live to users. Thoth Tech also has two products in development, a third external product called DreamBig, and an Internal Systems product for Thoth Tech employees. Each product is being developed during this trimester.
+Thoth Tech currently has two existing products, OnTrack and SplashKit, which are open source and
+live to users. Thoth Tech also has two products in development, a third external product called
+DreamBig, and an Internal Systems product for Thoth Tech employees. Each product is being developed
+during this trimester.
 
 ## OnTrack
 
-OnTrack is a platform designed to facilitate student learning by helping them achieve their unit learning outcomes and goals. It reduces pressure on achieving unrealistic grades, and importance on tailored content learning using tasks and a portfolio assessment.
+OnTrack is a platform designed to facilitate student learning by helping them achieve their unit
+learning outcomes and goals. It reduces pressure on achieving unrealistic grades, and importance on
+tailored content learning using tasks and a portfolio assessment.
 
-This approach provides students with a simple but effective way to demonstrate their achievements and learning outcomes with the assistance of teaching staff feedback throughout the unit. OnTrack is based on Doubtfire LMS and Thoth Tech is working towards creating new and enhanced features that improve the teaching and learning experience.
+This approach provides students with a simple but effective way to demonstrate their achievements
+and learning outcomes with the assistance of teaching staff feedback throughout the unit. OnTrack is
+based on Doubtfire LMS and Thoth Tech is working towards creating new and enhanced features that
+improve the teaching and learning experience.
 
 **Product Lead:** Jordan Cameron Trainor
 
@@ -272,21 +327,41 @@ This approach provides students with a simple but effective way to demonstrate t
 
 #### _Overview, Goals, and Objectives_
 
-The Front-end migration project aims to modernise the existing components that use CoffeeScript and Bootstrap, towards the cutting-edge framework, Angular with Typescript. CoffeeScript has become dated and lacks the functionality, security, and support that more modern frameworks provide. Angular, which is supported by Google, allows developers to leverage its component-based architecture to quickly create dynamic single-page applications. It is built using TypeScript, which ensures greater security as the language supports types and allows for early bug detection. Other features include templating, two-way binding, dependency injection, and extending HTML syntax without relying on third-party libraries. Moving to Angular will continue to uphold the integrity of OnTrack. TypeScript is accepted by a larger community base and includes more advanced and scalable features. Once migrations are completed, it’s possible to add more advanced and quicker features to OnTrack.
+The Front-end migration project aims to modernise the existing components that use CoffeeScript and
+Bootstrap, towards the cutting-edge framework, Angular with Typescript. CoffeeScript has become
+dated and lacks the functionality, security, and support that more modern frameworks provide.
+Angular, which is supported by Google, allows developers to leverage its component-based
+architecture to quickly create dynamic single-page applications. It is built using TypeScript, which
+ensures greater security as the language supports types and allows for early bug detection. Other
+features include templating, two-way binding, dependency injection, and extending HTML syntax
+without relying on third-party libraries. Moving to Angular will continue to uphold the integrity of
+OnTrack. TypeScript is accepted by a larger community base and includes more advanced and scalable
+features. Once migrations are completed, it’s possible to add more advanced and quicker features to
+OnTrack.
 
 #### _Aims for Trimester_
 
-The aim for the trimester is for each of the eight teams within the project to migrate at least one existing component and build experience to enable accelerated progress in future trimesters by supporting future team members.
+The aim for the trimester is for each of the eight teams within the project to migrate at least one
+existing component and build experience to enable accelerated progress in future trimesters by
+supporting future team members.
 
 #### _Deliverables_
 
-The Front-End migration team has taken a divide and conquer approach by allocating two people into a sub-team to ensure the amount of work is well distributed. This will allow for easier communication, teamwork, and workflow for more efficient progress.
+The Front-End migration team has taken a divide and conquer approach by allocating two people into a
+sub-team to ensure the amount of work is well distributed. This will allow for easier communication,
+teamwork, and workflow for more efficient progress.
 
-Based on existing documentation, there are 183 components remaining to migrate, however this may not be accurately updated. An analysis will be completed to ensure this is updated.
+Based on existing documentation, there are 183 components remaining to migrate, however this may not
+be accurately updated. An analysis will be completed to ensure this is updated.
 
-The trimester deliverables will be developing and delivering at least eight migrated components. However, the long-term project deliverables are to ensure all future teams are supported and set up for success to migrate all remaining components prior to CoffeeScript support being removed.
+The trimester deliverables will be developing and delivering at least eight migrated components.
+However, the long-term project deliverables are to ensure all future teams are supported and set up
+for success to migrate all remaining components prior to CoffeeScript support being removed.
 
-The functionality of the migrated components will be identical to the old ones, with a user interface design that fits in with the new OnTrack theme. Testing of these components must also be considered and implemented to ensure that the components will function as expected for students and faculty.
+The functionality of the migrated components will be identical to the old ones, with a user
+interface design that fits in with the new OnTrack theme. Testing of these components must also be
+considered and implemented to ensure that the components will function as expected for students and
+faculty.
 
 #### _Project Members (18)_
 
@@ -316,29 +391,53 @@ Team 8: Zheng Jiahao, Huang Yongqi
 
 #### _Overview, Goals, and Objectives_
 
-The Deployment project aim is to create an employee-run deployment of OnTrack separated from the existing Deakin version and hosted on Google Cloud. Due to the scale of the project, there are three subgroups within the project which will focus on Google Cloud deployment, CI/CD pipeline, and enhanced authentication. The objective of the Thoth Tech hosted version of OnTrack is to allow the company to own the deployment cadence, conduct end-to-end testing, reduce risks leaking bugs upstream an innovate on new features. In addition, stakeholders will have a much more efficient setup, as well an improved process for future employees contributing to the project. The pipeline will be focused on improving software delivery with a CI/CD approach to speed up development and provide a level of quality assurance, whilst the authentication system will ensure security and privacy.
+The Deployment project aim is to create an employee-run deployment of OnTrack separated from the
+existing Deakin version and hosted on Google Cloud. Due to the scale of the project, there are three
+subgroups within the project which will focus on Google Cloud deployment, CI/CD pipeline, and
+enhanced authentication. The objective of the Thoth Tech hosted version of OnTrack is to allow the
+company to own the deployment cadence, conduct end-to-end testing, reduce risks leaking bugs
+upstream an innovate on new features. In addition, stakeholders will have a much more efficient
+setup, as well an improved process for future employees contributing to the project. The pipeline
+will be focused on improving software delivery with a CI/CD approach to speed up development and
+provide a level of quality assurance, whilst the authentication system will ensure security and
+privacy.
 
 #### _Aims for Trimester_
 
-- Deploy a student-run version of OnTrack hosted on Google Cloud. This version will be running in isolation, independently of the Deakin University version.
-- Create a CI/CD pipeline that automates the building, deployment, and validation of a of the Thoth Tech OnTrack to Google Cloud.
-- Enable an enhanced authentication for user login which securely transmits data and protects stakeholder privacy.
+- Deploy a student-run version of OnTrack hosted on Google Cloud. This version will be running in
+  isolation, independently of the Deakin University version.
+- Create a CI/CD pipeline that automates the building, deployment, and validation of a of the Thoth
+  Tech OnTrack to Google Cloud.
+- Enable an enhanced authentication for user login which securely transmits data and protects
+  stakeholder privacy.
 
 #### _Deliverables_
 
 ##### **Google Cloud**
 
-Short term deliverables will be to Design and document the architecture overview and overall deployment, work collaboratively with relevant teams to automate the build, test, and deployment of OnTrack using a CI/CD pipeline, work collaboratively with relevant teams to allow for secure authentication for users of OnTrack and build a secure platform for the OnTrack deployment to be hosted on Google Cloud
+Short term deliverables will be to Design and document the architecture overview and overall
+deployment, work collaboratively with relevant teams to automate the build, test, and deployment of
+OnTrack using a CI/CD pipeline, work collaboratively with relevant teams to allow for secure
+authentication for users of OnTrack and build a secure platform for the OnTrack deployment to be
+hosted on Google Cloud
 
-Long term deliverables will be to host multiple environments (such as Production, Development, and potentially Test/Staging) of the OnTrack deployment in Google Cloud, as well as review further expansion to run multi-tenanted environments for Deakin University and other organisations within Google Cloud.
+Long term deliverables will be to host multiple environments (such as Production, Development, and
+potentially Test/Staging) of the OnTrack deployment in Google Cloud, as well as review further
+expansion to run multi-tenanted environments for Deakin University and other organisations within
+Google Cloud.
 
 ##### **Pipeline**
 
-The short-term deliverable is that there will be an automated build CI/CD pipeline in production building and deploying OnTrack on to the Google Cloud platform and ensuring it is documented for long term usage and maintenance.
+The short-term deliverable is that there will be an automated build CI/CD pipeline in production
+building and deploying OnTrack on to the Google Cloud platform and ensuring it is documented for
+long term usage and maintenance.
 
 ##### **Enhance Authentication**
 
-Short term deliverables will be focusing on the empathise, define, and ideate stages - by giving more time to designing the possible solution, the team can produce a better answer. When the blueprint is out, the team will use the rest of the time to work on making the prototypes. Creating LDAP (Lightweight Directory Access Protocol) servers and testing them.
+Short term deliverables will be focusing on the empathise, define, and ideate stages - by giving
+more time to designing the possible solution, the team can produce a better answer. When the
+blueprint is out, the team will use the rest of the time to work on making the prototypes. Creating
+LDAP (Lightweight Directory Access Protocol) servers and testing them.
 
 Long term deliverables will be continuous maintenance, improvement, and testing of the solution.
 
@@ -348,11 +447,9 @@ Long term deliverables will be continuous maintenance, improvement, and testing 
 
 **_Google CLoud_**
 
-**Cloud/DevOps Engineer:**
-Joyce Cruz
+**Cloud/DevOps Engineer:** Joyce Cruz
 
-**Back-end Developer:**
-Sultan Hindi A Albishri
+**Back-end Developer:** Sultan Hindi A Albishri
 
 **_Pipeline_**
 
@@ -362,9 +459,7 @@ Mathew Perkins
 
 Lachlan Cayzer
 
-**_Enhance Authentication_**
-**Full-stack Developer:**
-Linden Hutchinson
+**_Enhance Authentication_** **Full-stack Developer:** Linden Hutchinson
 
 Back-end Developer:
 
@@ -378,27 +473,39 @@ XueTing Jing
 
 #### _Overview, Goals, and Objectives_
 
-In the current version of the OnTrack product there is no support for submitting Jupyter Notebook ‘.ipynb’ files directly to OnTrack. As a result of this limitation, student users must export their Jupyter Notebook file as an HTML document, and then use a PDF converter to create a PDF suitable for uploading to OnTrack. This results in an inefficient, poor, and frustrating user experience.
+In the current version of the OnTrack product there is no support for submitting Jupyter Notebook
+‘.ipynb’ files directly to OnTrack. As a result of this limitation, student users must export their
+Jupyter Notebook file as an HTML document, and then use a PDF converter to create a PDF suitable for
+uploading to OnTrack. This results in an inefficient, poor, and frustrating user experience.
 
-The goal of this project is to solve this issue by allowing students to upload .ipynb files directly to OnTrack and utilise OnTrack’s PDF conversion pipeline to handle automatically converting the file to PDF format for the faculty staff to view.
+The goal of this project is to solve this issue by allowing students to upload .ipynb files directly
+to OnTrack and utilise OnTrack’s PDF conversion pipeline to handle automatically converting the file
+to PDF format for the faculty staff to view.
 
-The objective of this project is to help make using OnTrack a more efficient process and improve ease of use for students and staff involved in tasks that use Jupyter Notebook.
+The objective of this project is to help make using OnTrack a more efficient process and improve
+ease of use for students and staff involved in tasks that use Jupyter Notebook.
 
 #### _Aims for Trimester_
 
-For this trimester the Jupyter Notebook Support project team will review the existing work on this feature and create a plan to fully deliver the Jupyter Notebook file to PDF conversion feature.
+For this trimester the Jupyter Notebook Support project team will review the existing work on this
+feature and create a plan to fully deliver the Jupyter Notebook file to PDF conversion feature.
 
 #### _Deliverables_
 
-The deliverables for this project will be the introduction of PDF conversion functionality for ‘.ipynb’ files into OnTrack, as well as documentation on the feature and a user guide on how to utilise the feature.
+The deliverables for this project will be the introduction of PDF conversion functionality for
+‘.ipynb’ files into OnTrack, as well as documentation on the feature and a user guide on how to
+utilise the feature.
 
 - Give OnTrack the ability to accept ‘.ipynb’ files directly.
 - Have fully functioning ‘.ipynb’ to PDF conversion support integrated to Ontrack.
-- Have a proper user guide documentation for anyone to follow and get familiar with the implemented feature.
+- Have a proper user guide documentation for anyone to follow and get familiar with the implemented
+  feature.
 - Keep track of how often the feature is being used as well as any failed conversions in a log.
-- To make sure that the code the team write for this feature does not affect any existing features or dependencies.
+- To make sure that the code the team write for this feature does not affect any existing features
+  or dependencies.
 
-Long term deliverables beyond this trimester will be the maintenance and improvement of this feature.
+Long term deliverables beyond this trimester will be the maintenance and improvement of this
+feature.
 
 #### _Project Members (5)_
 
@@ -418,24 +525,35 @@ Matt Clark
 
 #### _Overview, Goals, and Objectives_
 
-Currently, the OnTrack product has the functionality to accept audio submissions, but no verification system. Voice Verification for the online audio submissions will help mitigate cheating attempts and plagiarism.
+Currently, the OnTrack product has the functionality to accept audio submissions, but no
+verification system. Voice Verification for the online audio submissions will help mitigate cheating
+attempts and plagiarism.
 
-In the past there have been teams who have worked on a Speaker Verification Library to validate audio files, a Speaker Verification API to wrap the library, and a Ruby app to integrate Doubtfire LMS and the Speaker Verification API. The objective of this project is to finalise a proof of concept for the Voice Verification system, deploy it to the Thoth Tech OnTrack environment, and deliver technical documentation.
+In the past there have been teams who have worked on a Speaker Verification Library to validate
+audio files, a Speaker Verification API to wrap the library, and a Ruby app to integrate Doubtfire
+LMS and the Speaker Verification API. The objective of this project is to finalise a proof of
+concept for the Voice Verification system, deploy it to the Thoth Tech OnTrack environment, and
+deliver technical documentation.
 
 #### _Aims for Trimester_
 
-The aim for this trimester is to work on understanding the work completed by previous teams, finish the voice verification feature, test the functionality, and create accurate documentation for the entirety of the Voice Verification system; architecture, deployment and how to user it.
+The aim for this trimester is to work on understanding the work completed by previous teams, finish
+the voice verification feature, test the functionality, and create accurate documentation for the
+entirety of the Voice Verification system; architecture, deployment and how to user it.
 
 #### _Deliverables_
 
-The short-term deliverables for this project will be upskilling, understanding, improving, integrating, testing, deploying, and developing any gaps identified in the existing pieces of work completed for the Voice Verification feature. This includes:
+The short-term deliverables for this project will be upskilling, understanding, improving,
+integrating, testing, deploying, and developing any gaps identified in the existing pieces of work
+completed for the Voice Verification feature. This includes:
 
 - A Proof-of-Concept integration of Speaker Verification on Doubtfire.
 - Enrolment: Students can register their voice
 - Verification: When a task submission is received, verify the attached voice file
 - Deployed to the Thoth Tech OnTrack instance
 
-There will also be the deliverable of creating documentation to ensure that the architecture, deployment, and user guides for recording voice samples for enrolment and verification.
+There will also be the deliverable of creating documentation to ensure that the architecture,
+deployment, and user guides for recording voice samples for enrolment and verification.
 
 The long-term deliverables for this project will be maintenance and improvements of this feature.
 
@@ -459,9 +577,17 @@ Yanjun Chen
 
 #### _Overview_
 
-The Documentation project objective is to create documentation for the Thoth Tech company and its products, including OnTrack. The current state of documentation of Thoth Tech’s products’ is poor; with previous design decisions, updates and feature implementations not accurately documented or maintained. By clearly documenting the products Thoth Tech’s employees will be set up for success to hit the ground running when joining the company and a team. Additionally, the products’ end users, which include university students and educators, will find it easy to learn and use the products with simple and accessible documentation at hand.
+The Documentation project objective is to create documentation for the Thoth Tech company and its
+products, including OnTrack. The current state of documentation of Thoth Tech’s products’ is poor;
+with previous design decisions, updates and feature implementations not accurately documented or
+maintained. By clearly documenting the products Thoth Tech’s employees will be set up for success to
+hit the ground running when joining the company and a team. Additionally, the products’ end users,
+which include university students and educators, will find it easy to learn and use the products
+with simple and accessible documentation at hand.
 
-The objective of the team is to create a smooth onboarding process and simplify the process of creating and managing documentation across the Thoth Tech products, for all teams. Having good documentation for the future trimesters will result in higher productivity and increasing progress.
+The objective of the team is to create a smooth onboarding process and simplify the process of
+creating and managing documentation across the Thoth Tech products, for all teams. Having good
+documentation for the future trimesters will result in higher productivity and increasing progress.
 
 The goals of the documentation project are to:
 
@@ -473,13 +599,24 @@ The goals of the documentation project are to:
 
 #### _Aims for Trimester_
 
-The documentation team’s aim for the trimester is to ensure everything related to Thoth Tech is efficiently and accurately documented moving forward. By collating existing documentation, analysing gaps, collaborating with development teams’, and creating new documentation, the contributions made by the documentation team will set up future team leaders and members who decide to join Thoth Tech for success.
+The documentation team’s aim for the trimester is to ensure everything related to Thoth Tech is
+efficiently and accurately documented moving forward. By collating existing documentation, analysing
+gaps, collaborating with development teams’, and creating new documentation, the contributions made
+by the documentation team will set up future team leaders and members who decide to join Thoth Tech
+for success.
 
 #### _Deliverables_
 
-The first short-term deliverable for this project is to establish documentation guidelines and processes for all teams within the company to create and organise documentation for use, operation, maintenance, design, test, and access. This will ensure accountability and compliance to documentation standards and that documentation is highly accessible. The second deliverable for this project is to analyse the Ontrack repository for relevant documentation that needs to be updated, improved, or created if none exists already. This includes design documentation, requirement documentation, user documentation for development and user guides.
+The first short-term deliverable for this project is to establish documentation guidelines and
+processes for all teams within the company to create and organise documentation for use, operation,
+maintenance, design, test, and access. This will ensure accountability and compliance to
+documentation standards and that documentation is highly accessible. The second deliverable for this
+project is to analyse the Ontrack repository for relevant documentation that needs to be updated,
+improved, or created if none exists already. This includes design documentation, requirement
+documentation, user documentation for development and user guides.
 
-The long-term deliverables are to ensure that all documentation is kept up to date with changes made to the products, and to perform the same analysis and work on the SplashKit product.
+The long-term deliverables are to ensure that all documentation is kept up to date with changes made
+to the products, and to perform the same analysis and work on the SplashKit product.
 
 #### _Project Members (7)_
 
@@ -501,7 +638,18 @@ Shivam Singh
 
 ## SplashKit
 
-SplashKit is an open-source Software Development Kit (SDK)​, created with the purpose of reducing the overhead required for truly technical coding​ and allowing students new to coding to create satisfying programs in a short period of time. SplashKit enables beginning coders to quickly learn to construct fun and functional programs which they can be proud to showcase. SplashKit is an open-source Software Development Kit (SDK)​, created with the purpose of reducing the overhead required for truly technical coding​ which enables students new to coding to create satisfying programs in a short period of time. SplashKit enables novice coders to quickly learn to construct fun and functional programs which they can be proud to showcase. It includes a large library of functions which can be utilized by the user to experiment and apply for their own application or game. This product is currently used by the students at Deakin University and aims to become a global educational toolkit. Currently the language used for development is C++ and the direction of the product is to improve and expand the capabilities to increase SplashKit accessibility.
+SplashKit is an open-source Software Development Kit (SDK)​, created with the purpose of reducing
+the overhead required for truly technical coding​ and allowing students new to coding to create
+satisfying programs in a short period of time. SplashKit enables beginning coders to quickly learn
+to construct fun and functional programs which they can be proud to showcase. SplashKit is an
+open-source Software Development Kit (SDK)​, created with the purpose of reducing the overhead
+required for truly technical coding​ which enables students new to coding to create satisfying
+programs in a short period of time. SplashKit enables novice coders to quickly learn to construct
+fun and functional programs which they can be proud to showcase. It includes a large library of
+functions which can be utilized by the user to experiment and apply for their own application or
+game. This product is currently used by the students at Deakin University and aims to become a
+global educational toolkit. Currently the language used for development is C++ and the direction of
+the product is to improve and expand the capabilities to increase SplashKit accessibility.
 
 **Product Lead:** Yash Kondlekar
 
@@ -509,14 +657,21 @@ SplashKit is an open-source Software Development Kit (SDK)​, created with the
 
 #### _Overview, Goals, and Objectives_
 
-The Programming Arcana is an open-source friendly programming textbook that teaches introductory programming concepts to those new to programming. From the programming Arcana’s GitHub, the guiding principles are:
+The Programming Arcana is an open-source friendly programming textbook that teaches introductory
+programming concepts to those new to programming. From the programming Arcana’s GitHub, the guiding
+principles are:
 
 - Transferable concepts are more important than language specifics
 - Build concepts on top of known concepts as much as possible
 - Focus on procedural programming initially, with a view to transitioning to objects
 - Build programs that make it easy to see what is happening in the code
 
-The programming Arcana currently has two versions, 1.0.x and 2.0.x. Version 1.0.x uses Tex as its typesetting system. Version 2.0.x uses Markdown as its typesetting system. This version also uses NodeJS and React to deploy a website. Version 2.0.x is still in progress; therefore, goals include finishing the documents, creating different programming language examples, and migrating the programming Arcana into SplashKit which would allow the SplashKit users to view the programming Arcana as they are developing resulting in an enhanced learning experience.
+The programming Arcana currently has two versions, 1.0.x and 2.0.x. Version 1.0.x uses Tex as its
+typesetting system. Version 2.0.x uses Markdown as its typesetting system. This version also uses
+NodeJS and React to deploy a website. Version 2.0.x is still in progress; therefore, goals include
+finishing the documents, creating different programming language examples, and migrating the
+programming Arcana into SplashKit which would allow the SplashKit users to view the programming
+Arcana as they are developing resulting in an enhanced learning experience.
 
 #### _Aims for Trimester_
 
@@ -552,24 +707,38 @@ Long-term:
 
 #### _Overview, Goals, and Objectives_
 
-SplashKit is a product that has been developed to abstract away the complexities of programming languages for novice programmers. However, the toolchains and development environments required to use SplashKit can be difficult and confusing to see tup for inexperienced users. Some aspects of these issues have already been eased using SplashKit’s current install script, but it’s been observed that the initial installation process for “skm" could be further simplified.
+SplashKit is a product that has been developed to abstract away the complexities of programming
+languages for novice programmers. However, the toolchains and development environments required to
+use SplashKit can be difficult and confusing to see tup for inexperienced users. Some aspects of
+these issues have already been eased using SplashKit’s current install script, but it’s been
+observed that the initial installation process for “skm" could be further simplified.
 
-The Distribution Channel Team intends to improve the installation process of SplashKit for new users across all three major operating systems; Windows, Linux and macOS.
+The Distribution Channel Team intends to improve the installation process of SplashKit for new users
+across all three major operating systems; Windows, Linux and macOS.
 
-The result of these improvements aims to be a single command or executable installation process that yields a working development environment for SplashKit on Windows, Linux or macOS ready for the user to start using SplashKit as quickly as possible. Decreasing the friction of the installation process aims to streamline the setup process for new users, potentially adding both product value to SplashKit – and confidence to new users.
+The result of these improvements aims to be a single command or executable installation process that
+yields a working development environment for SplashKit on Windows, Linux or macOS ready for the user
+to start using SplashKit as quickly as possible. Decreasing the friction of the installation process
+aims to streamline the setup process for new users, potentially adding both product value to
+SplashKit – and confidence to new users.
 
 #### _Aims for Trimester_
 
 The main aims for the Distribution Channel Team this trimester:
 
-- Research the existing installation process, the SplashKit management tool “skm”, and possible methods of improved installation on all three major operating systems.
-- Research and report on current known issues with respect to the installation of SplashKit on all three major operating systems.
+- Research the existing installation process, the SplashKit management tool “skm”, and possible
+  methods of improved installation on all three major operating systems.
+- Research and report on current known issues with respect to the installation of SplashKit on all
+  three major operating systems.
 - Report on future possibilities
 - Investigate issues with Mac M1 chip devices
 
 #### _Deliverables_
 
-Currently the deliverables planned for Sprint 1 will be to investigate the user and customer requirements in installing splash kit on Linux, Windows, and Mac OS (including the recent M1 chip). These deliverables are critical to the scoping of future deliverables and direction for our team as once completed, potential solutions can be determined, and tasks delegated accordingly.
+Currently the deliverables planned for Sprint 1 will be to investigate the user and customer
+requirements in installing splash kit on Linux, Windows, and Mac OS (including the recent M1 chip).
+These deliverables are critical to the scoping of future deliverables and direction for our team as
+once completed, potential solutions can be determined, and tasks delegated accordingly.
 
 The current deliverables intended for completion prior to the conclusion of sprint 1 are as follows:
 
@@ -582,7 +751,8 @@ The current deliverables intended for completion prior to the conclusion of spri
   - Could containerisation containing all dependencies be streamlined enough for users?
   - Can the dependencies be installed in one downloadable bash/PowerShell script?
 
-Our expectation is that the information gathered will to turn these into long-term deliverables and break those down into deliverables for the upcoming Sprint 2 and 3.
+Our expectation is that the information gathered will to turn these into long-term deliverables and
+break those down into deliverables for the upcoming Sprint 2 and 3.
 
 #### _Project Members (4)_
 
@@ -600,14 +770,20 @@ Trent Mizzi
 
 #### _Overview, Goals, and Objectives_
 
-The SplashKit translator is a Ruby application that translates the original cpp library into a target language. Currently, the translator enables translation of the SplashKit library into Python (< 3.8), Pascal, Rust, and C#. The SplashKit Extensions project’s aim is to provide the SplashKit library interface in additional languages.
+The SplashKit translator is a Ruby application that translates the original cpp library into a
+target language. Currently, the translator enables translation of the SplashKit library into Python
+(< 3.8), Pascal, Rust, and C#. The SplashKit Extensions project’s aim is to provide the SplashKit
+library interface in additional languages.
 
-Translating the SplashKit library into other languages provides the flexibility to teach other languages using SplashKit as well as increase the adoption of SplashKit. The project also ensures SplashKit’s continued relevance in a changing field.
+Translating the SplashKit library into other languages provides the flexibility to teach other
+languages using SplashKit as well as increase the adoption of SplashKit. The project also ensures
+SplashKit’s continued relevance in a changing field.
 
 #### _Aims for Trimester_
 
 - Understand how the language translators works
-- Investigate changes in Python between 3.8x versions and earlier to identify which of these changes have caused current incompatibilities.
+- Investigate changes in Python between 3.8x versions and earlier to identify which of these changes
+  have caused current incompatibilities.
 - Get SplashKit successfully working on the latest Python version (3.10.x).
 - Develop a new language translation for the Translator.
 - Test all existing and new language translations.
@@ -617,12 +793,15 @@ Translating the SplashKit library into other languages provides the flexibility 
 
 Short-term:
 
-- Documentation of the installation/setup of the SplashKit translator for development (Windows/Linux).
+- Documentation of the installation/setup of the SplashKit translator for
+  development (Windows/Linux).
 - Documentation of the installation/setup and operation of the SplashKit translator.
 - Documentation of the process to test each of the language translations.
 - At least 1 working language extension for SplashKit.
-- SplashKit translated into Python compatible with version 3.10.x and backwards compatible (if possible).
-- Project decisions documentation to provide evidence-based decision-making history for future teams.
+- SplashKit translated into Python compatible with version 3.10.x and backwards compatible (if
+  possible).
+- Project decisions documentation to provide evidence-based decision-making history for future
+  teams.
 
 Long-term:
 
@@ -654,17 +833,23 @@ Timothy Wilbert
 
 #### _Overview, Goals, and Objectives_
 
-The goal of this project is to create a physical arcade machine with accompanying software to showcase student games, developed with the [SplashKit](https://splashkit.io/) SDK. The machine will perform similarly to a Multi-Game Arcade Machine, allowing users to select a game from a local library of games. Our system ideally will instead have access to a growing library of SplashKit games publicly hosted on the internet. Objectives include:
+The goal of this project is to create a physical arcade machine with accompanying software to
+showcase student games, developed with the [SplashKit](https://splashkit.io/) SDK. The machine will
+perform similarly to a Multi-Game Arcade Machine, allowing users to select a game from a local
+library of games. Our system ideally will instead have access to a growing library of SplashKit
+games publicly hosted on the internet. Objectives include:
 
 - Software which supports the ability to:
   - Upload games to the Arcade Machine
   - Select and play games on the Arcade Machine
 - The development of:
-  - A vetting process which validates and reviews games for explicit/unacceptable content before addition
+  - A vetting process which validates and reviews games for explicit/unacceptable content before
+    addition
   - A user guide walking through the process of uploading games to the system.
   - Documentation
 
-Additional features which may be considered later in the lifecycle of the project include the development and deployment of a website which:
+Additional features which may be considered later in the lifecycle of the project include the
+development and deployment of a website which:
 
 - Supports the uploading of games
 - Stores and displays:
@@ -673,14 +858,20 @@ Additional features which may be considered later in the lifecycle of the projec
 
 #### _Aims for Trimester_
 
-The primary aim of this trimester is to develop a platform which supports the uploading, storage, and access to a growing library of games developed using the SplashKit SDK. Access to the game library will be offered through the platform where the user can configure settings and select and play their desired game. If time permits, a physical Arcade Machine will be designed and manufactured however the software platform is the primary focus for the trimester.
+The primary aim of this trimester is to develop a platform which supports the uploading, storage,
+and access to a growing library of games developed using the SplashKit SDK. Access to the game
+library will be offered through the platform where the user can configure settings and select and
+play their desired game. If time permits, a physical Arcade Machine will be designed and
+manufactured however the software platform is the primary focus for the trimester.
 
 #### _Deliverables_
 
 Short-term:
 
-- Platform which can access, download, and play SplashKit games stored in a public library on the internet.
-- Production of a physical Arcade Machine which runs on the platform to showcase SplashKit games created by students during university open days.
+- Platform which can access, download, and play SplashKit games stored in a public library on the
+  internet.
+- Production of a physical Arcade Machine which runs on the platform to showcase SplashKit games
+  created by students during university open days.
 
 Long-term:
 
@@ -704,17 +895,24 @@ Sarah Gosling
 
 #### _Overview, Goals, and Objectives_
 
-The project that the Build a Cool Game team has is to make games that can be showcased and played on the Arcade machine that is going to be virtually built. The goal is to make a game that uses all functions that SplashKit has to offer within game creation. The long-term goal will showcase that SplashKit can be extended upon as a game engine and can create games that can be played on different platforms. As SplashKit is widely used to create 2D games, it will be a good opportunity to showcase how SplashKit games can be extended and shown on a physical arcade machine.
+The project that the Build a Cool Game team has is to make games that can be showcased and played on
+the Arcade machine that is going to be virtually built. The goal is to make a game that uses all
+functions that SplashKit has to offer within game creation. The long-term goal will showcase that
+SplashKit can be extended upon as a game engine and can create games that can be played on different
+platforms. As SplashKit is widely used to create 2D games, it will be a good opportunity to showcase
+how SplashKit games can be extended and shown on a physical arcade machine.
 
 #### _Aims for Trimester_
 
-The aim for this trimester is to work on game creation using SplashKit. This must incorporate all the functions that SplashKit has to make the games. This will showcase the creation tools that game developers can use to create a game from scratch so that it can be played on the arcade machine.
+The aim for this trimester is to work on game creation using SplashKit. This must incorporate all
+the functions that SplashKit has to make the games. This will showcase the creation tools that game
+developers can use to create a game from scratch so that it can be played on the arcade machine.
 
-_Deliverables_
-Short-term:
+_Deliverables_ Short-term:
 
 - Cool 2D games demonstrating all functionality of SplashKit. (Minimum 1 per team member)
-- A step-by-step article guide of How to create the Cool games produced (Document design decisions, process and how-to-guides)
+- A step-by-step article guide of How to create the Cool games produced (Document design decisions,
+  process and how-to-guides)
 - Guide uploaded to the SplashKit.io website.
 
 Long-term:
@@ -738,15 +936,31 @@ Bella Chhour
 
 #### Overview, Goals, and Objectives
 
-Across three modules, Physics, Data Analytics and Machine Learning, SplashKit aims to enrich and expand its functionality, to improve current features and extend its user base beyond game development. In the next two years, SplashKit aims to develop a full 2D physics engine that can be used by game developers, requiring the addition of a realistic and easy to use physics library. New capabilities to interact with, visualise, and analyse data are aiming to attract new users and provide data analytics functionalities for the existing user base.
+Across three modules, Physics, Data Analytics and Machine Learning, SplashKit aims to enrich and
+expand its functionality, to improve current features and extend its user base beyond game
+development. In the next two years, SplashKit aims to develop a full 2D physics engine that can be
+used by game developers, requiring the addition of a realistic and easy to use physics library. New
+capabilities to interact with, visualise, and analyse data are aiming to attract new users and
+provide data analytics functionalities for the existing user base.
 
-SplashKit’s current objective for Machine Learning is to develop an Artificial Intelligence framework that allows the inclusion of artificial co-op or opposition characters into SplashKit games, with a long-term goal to integrate with the Data Analytics module and to create a complete Machine Learning framework.
+SplashKit’s current objective for Machine Learning is to develop an Artificial Intelligence
+framework that allows the inclusion of artificial co-op or opposition characters into SplashKit
+games, with a long-term goal to integrate with the Data Analytics module and to create a complete
+Machine Learning framework.
 
 #### _Aims for Trimester_
 
-This trimester, the team are aiming to finalise and publish the existing work completed for all three modules. The Physics and Data Analytics team are aiming to review and publish the existing elastic collision, impulse effect, and data frame code from past developers, whilst the Machine Learning team is expecting to use the example code from past developers as reference to build a brand-new system.
+This trimester, the team are aiming to finalise and publish the existing work completed for all
+three modules. The Physics and Data Analytics team are aiming to review and publish the existing
+elastic collision, impulse effect, and data frame code from past developers, whilst the Machine
+Learning team is expecting to use the example code from past developers as reference to build a
+brand-new system.
 
-The team aims to produce new functionality this trimester to the existing code, including extending the physics API to complete the handing of 2D sprite and object collisions, and implementing gravity. Data Analytics team plan to extend data frames to allow instance selection, standardisation, transformation, and feature selection. Machine Learning team aims to design a reinforcement learning algorithm that is capable of co-op or opposition AI in SplashKit games.
+The team aims to produce new functionality this trimester to the existing code, including extending
+the physics API to complete the handing of 2D sprite and object collisions, and implementing
+gravity. Data Analytics team plan to extend data frames to allow instance selection,
+standardisation, transformation, and feature selection. Machine Learning team aims to design a
+reinforcement learning algorithm that is capable of co-op or opposition AI in SplashKit games.
 
 #### _Deliverables_
 
@@ -756,11 +970,14 @@ Short term:
 - Verified existing code documented and pushed to SplashKit repository.
 - New feature documentation (user guides)
 - Physics:
-  - Physics artefact enhancing collisions between sprites and objects, and gravity that acts on them.
+  - Physics artefact enhancing collisions between sprites and objects, and gravity that acts on
+    them.
 - Data Analytics:
-  - Deliver new code that enables instance selection, standardisation, transformation, and feature selection on the existing Data Frames.
+  - Deliver new code that enables instance selection, standardisation, transformation, and feature
+    selection on the existing Data Frames.
 - Machine Learning:
-  - Design and prototype a reinforcement learning algorithm, providing evidence of research and design, that will be capable of training co-op and villain characters in SplashKit games.
+  - Design and prototype a reinforcement learning algorithm, providing evidence of research and
+    design, that will be capable of training co-op and villain characters in SplashKit games.
 
 Long term:
 
@@ -769,26 +986,24 @@ Long term:
 - Implementing new features
   - Implement sinking objects and projectile motion (Physics team)
   - Implement visual plotting and statistics (Data Analytics team)
-  - Implement function approximation to the designed reinforcement learning algorithm (Machine Learning team)
+  - Implement function approximation to the designed reinforcement learning algorithm (Machine
+    Learning team)
 
 #### _Project Members (8)_
 
 **Delivery Lead:** Alex Hocking
 
-**Machine Learning**
-**Developer:**
+**Machine Learning** **Developer:**
 
 Harry Dentry
 
-**Physics**
-**Software Developer:**
+**Physics** **Software Developer:**
 
 Daniel Robert Haysham
 
 Kanna Srilakshmanan
 
-**Data Analytics**
-**Software Developer:**
+**Data Analytics** **Software Developer:**
 
 Ryan Allan Lawrence
 
@@ -798,7 +1013,12 @@ Kai Tao
 
 ## DreamBig
 
-DreamBig is a new product innovation driven by the School of IT at Deakin. DreamBig aims to provide a personalised roadmap integrated with Ontrack to support students to develop their professional identity across their course and improve their employability after graduation. In addition, it aims to provide a platform to help set realistic expectations for students graduating into the real world. In line with this vision, it is proposed to build a prototype that can help achieve the following goals:
+DreamBig is a new product innovation driven by the School of IT at Deakin. DreamBig aims to provide
+a personalised roadmap integrated with Ontrack to support students to develop their professional
+identity across their course and improve their employability after graduation. In addition, it aims
+to provide a platform to help set realistic expectations for students graduating into the real
+world. In line with this vision, it is proposed to build a prototype that can help achieve the
+following goals:
 
 - Multi-dimensional visualisation of each student's growing professional identity
 - Used within curriculum to encourage engagement.
@@ -812,11 +1032,16 @@ DreamBig is a new product innovation driven by the School of IT at Deakin. Dre
 
 #### _Overview, Goals, and Objectives_
 
-DreamBig is at its early inception. The customer needs and product requirements are still yet discovered and refined. The Prototype project is an attempt to explore the product-market fit. The process includes determining our target customer, identifying underserved customer needs, defining the product value proposition, specifying the MVP feature set, building, and testing the prototype with the customers.
+DreamBig is at its early inception. The customer needs and product requirements are still yet
+discovered and refined. The Prototype project is an attempt to explore the product-market fit. The
+process includes determining our target customer, identifying underserved customer needs, defining
+the product value proposition, specifying the MVP feature set, building, and testing the prototype
+with the customers.
 
 #### _Aims for Trimester_
 
-Research will be conducted to investigate customer needs and prioritise high-value features. These will form the minimum viable product (MVP). As part of this work, the following will be established:
+Research will be conducted to investigate customer needs and prioritise high-value features. These
+will form the minimum viable product (MVP). As part of this work, the following will be established:
 
 - High-level UX and UI approach
 - Documentation of user flows
@@ -841,11 +1066,9 @@ Long-term:
 
 **Delivery Lead:** Nehanjajli Makineni
 
-**Back-end Integration Developer:**
-Zac Brydon
+**Back-end Integration Developer:** Zac Brydon
 
-**Database Engineer:**
-Munatsi Matipana
+**Database Engineer:** Munatsi Matipana
 
 **Documentation & Security Specialist:**
 
@@ -861,7 +1084,10 @@ Harry Lui
 
 ## Internal Systems
 
-The internal systems product is a new initiative driven mitigating the challenge of the Thoth Tech company turning over half its employees every four months. The aim of this is to provide an accessible centralized location to display key company information and documentation which is sourced from the Thoth Tech repo.
+The internal systems product is a new initiative driven mitigating the challenge of the Thoth Tech
+company turning over half its employees every four months. The aim of this is to provide an
+accessible centralized location to display key company information and documentation which is
+sourced from the Thoth Tech repo.
 
 **Product Lead:** Abigail Howe
 
@@ -869,15 +1095,24 @@ The internal systems product is a new initiative driven mitigating the challenge
 
 #### _Overview, Goals, and Objectives_
 
-The goal for the Internal systems team is to research, scope, plan and prototype a web page that will house all necessary information for Thoth Tech. To achieve this the main objectives across the Internal Systems team will be to research different tools, technologies and processes and decide on what will best serve requirements and given team member skills whilst also allowing for expansion and adaptability in the future. The web page will create a centralised location for all the company’s information needed for its internal audience. This in turn will simplify the onboarding and resource sharing amongst the company and its everchanging audiences.
+The goal for the Internal systems team is to research, scope, plan and prototype a web page that
+will house all necessary information for Thoth Tech. To achieve this the main objectives across the
+Internal Systems team will be to research different tools, technologies and processes and decide on
+what will best serve requirements and given team member skills whilst also allowing for expansion
+and adaptability in the future. The web page will create a centralised location for all the
+company’s information needed for its internal audience. This in turn will simplify the onboarding
+and resource sharing amongst the company and its everchanging audiences.
 
 #### _Aims for Trimester_
 
-The aim this trimester is to plan out the architecture needed, design the page, and create documentation that will serve as a solid base for the progressive development of the web page.
+The aim this trimester is to plan out the architecture needed, design the page, and create
+documentation that will serve as a solid base for the progressive development of the web page.
 
-An understanding will be built of components required and the privacy and privileges needed by different users. A prototype will also be built that will showcase the design and functionality.
+An understanding will be built of components required and the privacy and privileges needed by
+different users. A prototype will also be built that will showcase the design and functionality.
 
-Git will be used to manage team contributions to the development of the web page and guidelines will be created for the testing structure utilised.
+Git will be used to manage team contributions to the development of the web page and guidelines will
+be created for the testing structure utilised.
 
 #### Deliverables
 

--- a/docs/company/roles.md
+++ b/docs/company/roles.md
@@ -13,7 +13,8 @@
 - Be a collaborator
 - Be transparent and accountable - visualisation of objectives
 - Communicate of what we are doing, what our plans are, and what we need
-- Owen stakeholder management - translating high level to low level and vice versa to communicate progress
+- Owen stakeholder management - translating high level to low level and vice versa to communicate
+  progress
 - Own risk and issues management.
 
 ## Product Lead

--- a/docs/data/data-strategy.md
+++ b/docs/data/data-strategy.md
@@ -79,8 +79,8 @@ MDA has the following characteristics:
   - Real-time Data
   - Third Party Feeds
 
-We must not acquire all of the above capabilities. In fact, these are driven by the company's
-short and long term needs.
+We must not acquire all of the above capabilities. In fact, these are driven by the company's short
+and long term needs.
 
 ## Data Governance
 
@@ -98,9 +98,9 @@ graph LR
   C[Data Creation] --> P[Data Processing] --> S[Data Storage] --> U[Data Usage] --> A[Data Archiving] --> D[Data Destruction]
 ```
 
-Data Governance must bring together people, processes and technology to govern data throughout
-its life cycle. It is not a trivial task and requires collaboration across the organisation. For
-Thoth Tech, we propose the adoption of the Data Governance Framework by Evren et al. (2021)
+Data Governance must bring together people, processes and technology to govern data throughout its
+life cycle. It is not a trivial task and requires collaboration across the organisation. For Thoth
+Tech, we propose the adoption of the Data Governance Framework by Evren et al. (2021)
 
 ![data governance over life cycle](images/data-governance-over-life-cycle.jpq)
 

--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -1,6 +1,7 @@
 # Data
 
-Welcome to the Data Handbook. The purpose of this space is to help you understand our company data direction, principles and architecture.
+Welcome to the Data Handbook. The purpose of this space is to help you understand our company data
+direction, principles and architecture.
 
 - [Data Strategy](data-strategy.md)
 - [Project Metrics template](project-metrics-template.md)

--- a/docs/data/project-metrics-template.md
+++ b/docs/data/project-metrics-template.md
@@ -6,7 +6,9 @@ A high-level summary of the project goals.
 
 ### Example
 
-This document outlines project objectives, including those related to people, delivery and product. It aims to provide a systematic and quantifiable set of key results that could guide us to build better teams, deliver more efficiently and delight our users.
+This document outlines project objectives, including those related to people, delivery and product.
+It aims to provide a systematic and quantifiable set of key results that could guide us to build
+better teams, deliver more efficiently and delight our users.
 
 ## Objective 1
 
@@ -21,11 +23,13 @@ List the key objective that your project should focus on this Trimester.
 
 ### Key Results
 
-Define the key results (KR) that support the above objective. Please make sure these KRs are specific, measurable and time-bound. They typically include hard numbers.
+Define the key results (KR) that support the above objective. Please make sure these KRs are
+specific, measurable and time-bound. They typically include hard numbers.
 
 **Examples**
 
-If the objective is to successfully launch a new product feature by the end of Trimester 1, then the key results are:
+If the objective is to successfully launch a new product feature by the end of Trimester 1, then the
+key results are:
 
 - Interview at least 10 prospective users and get their initial feedback
 - Specify all major user flows

--- a/docs/leadership/epic-example.md
+++ b/docs/leadership/epic-example.md
@@ -2,20 +2,24 @@
 
 ## Background / Context
 
-Employees currently would click on a link to take them to the ATO’s website to fill in a blank superannuation form (Standard choice form (PDF, 341KB)This link will download a file).
+Employees currently would click on a link to take them to the ATO’s website to fill in a blank
+superannuation form (Standard choice form (PDF, 341KB)This link will download a file).
 
 - Is this well used?
-- Has there been surveys to show that it would be good if we can have a pre-filled form given employees may have provided that information before?
+- Has there been surveys to show that it would be good if we can have a pre-filled form given
+  employees may have provided that information before?
 
 ## Business Value
 
-To minimise the double handling of super choice information by employers and also requiring employees to fill in the super form, the business would like to explore the possibility of having the forms pre-filled based on the information given by the employees to date.
-This will not only make it more convenient and efficient as part of the onboarding process, but also minimise the human error that may come with manual handling of the super info.
+To minimise the double handling of super choice information by employers and also requiring
+employees to fill in the super form, the business would like to explore the possibility of having
+the forms pre-filled based on the information given by the employees to date. This will not only
+make it more convenient and efficient as part of the onboarding process, but also minimise the human
+error that may come with manual handling of the super info.
 
 ## In Scope
 
-Part of Employee onboarding process
-Employees who were onboarded via Flare onboarding process
+Part of Employee onboarding process Employees who were onboarded via Flare onboarding process
 
 ## Out of Scope
 
@@ -23,8 +27,10 @@ Employees who are not initially onboarded by the Flare onboarding process?
 
 ## What needs to happen
 
-The current link to download a file shows only if Employee are not initially onboarded via Flare. This link is relabelled to “Download standard choice form from ATO website”. This link is not visible when Employee was onboarded via Flare.
-If Employee was onboarded via Flare, this link will appear: “Download pre-filled standard choice form.”
+The current link to download a file shows only if Employee are not initially onboarded via Flare.
+This link is relabelled to “Download standard choice form from ATO website”. This link is not
+visible when Employee was onboarded via Flare. If Employee was onboarded via Flare, this link will
+appear: “Download pre-filled standard choice form.”
 
 - Are there minimum validation rules for form fill we need to consider?
 - Does the UI need to show what parts of the super choice form hasn’t been filled?
@@ -36,12 +42,13 @@ If Employee was onboarded via Flare, this link will appear: “Download pre-fill
 
 ## UX/UI Considerations
 
-Do we provide both links or hide the one that least applies? Do we still give them the choice of getting the blank form?
+Do we provide both links or hide the one that least applies? Do we still give them the choice of
+getting the blank form?
 
 ## Analytics Considerations
 
-Capture how many employees use the pre-filled form link vs the blank form link
-Do we currently capture the usage of the generic blank form link?
+Capture how many employees use the pre-filled form link vs the blank form link Do we currently
+capture the usage of the generic blank form link?
 
 ## Reg & Compliance Considerations
 
@@ -51,8 +58,8 @@ Not known
 
 Advise teams 2 weeks in advance of planned release
 
-What are the challenges?
-What is a reasonable measure / response time to produce and download the pre-filled form?
+What are the challenges? What is a reasonable measure / response time to produce and download the
+pre-filled form?
 
 ## Acceptance criteria
 
@@ -61,5 +68,7 @@ What is a reasonable measure / response time to produce and download the pre-fil
 - Test with employees who were onboarded via Flare onboarding
 - Test with employees who were not onboarded via Flare onboarding
 - (NFR) Test pre-filled form is produced within 10 seconds
-- (If applicable) test with employees onboarded via Flare who have not completed super choice details
-- (If applicable) test with employees onboarded via Flare who have provided super choice details but are not valid
+- (If applicable) test with employees onboarded via Flare who have not completed super choice
+  details
+- (If applicable) test with employees onboarded via Flare who have provided super choice details but
+  are not valid

--- a/docs/leadership/meetings.md
+++ b/docs/leadership/meetings.md
@@ -2,8 +2,7 @@
 
 ## Welcome leads
 
-This meeting gives senior leadership team, product and delivery leads an
-opportunity to:
+This meeting gives senior leadership team, product and delivery leads an opportunity to:
 
 - Get to know each other and build rapport
 - Provide an opportunity to ask questions
@@ -13,11 +12,10 @@ opportunity to:
 
 1. Introduction.
 1. Do you think anything should be added to the Lead descriptions?
-1. Please confirm that you have access to tools that allow to do your job (Miro,
-   Trello, GitHub, etc.)
+1. Please confirm that you have access to tools that allow to do your job (Miro, Trello, GitHub,
+   etc.)
 1. Run through existing documents and resources, old Pull Request, etc.
-1. What should our leadership cadence be? How often do your teams do stand ups,
-   and retros?
+1. What should our leadership cadence be? How often do your teams do stand ups, and retros?
 1. Walk through delivery and product lead [roles](../company/roles.md).
 1. Support structure.
 1. Think about what your goals as leaders are - what skills can we help you develop?
@@ -25,5 +23,5 @@ opportunity to:
 1. Remind to fill in the Leadership skills matrix & availability form.
 
 If time permits, go through the role-specific
-[onboarding process](../peopleops/onboarding/onboarding-process.md) for delivery and
-products lead clarify any concerns.
+[onboarding process](../peopleops/onboarding/onboarding-process.md) for delivery and products lead
+clarify any concerns.

--- a/docs/learning/training/changing-git-fork-location.md
+++ b/docs/learning/training/changing-git-fork-location.md
@@ -20,8 +20,8 @@ If you followed the onboarding instructions, it should return something like thi
 
     https://github.com/[YOUR_GITHUB_USERNAME]/splashkit-core.git
 
-This link should point to the fork you made of the base repository on GitHub.
-Now we'll check if you forked from the right repository...
+This link should point to the fork you made of the base repository on GitHub. Now we'll check if you
+forked from the right repository...
 
 **3. Navigate to your fork on GitHub via the GitHub web interface**
 
@@ -31,8 +31,8 @@ The URL should look something like this:
 
 **4. Check where it's forked from**
 
-This is right under the repository name in the top left of the page.
-It should look something like this:
+This is right under the repository name in the top left of the page. It should look something like
+this:
 
     forked from **thoth-tech**/splashkit-core
 
@@ -42,7 +42,8 @@ And _should not_ look like this:
 
 # I forked from the wrong repo; how do I change it?
 
-If you forked from the wrong repo and you haven’t made any commits, then the easiest option is to start over. If you have made commits you will need to change the fork location like this...
+If you forked from the wrong repo and you haven’t made any commits, then the easiest option is to
+start over. If you have made commits you will need to change the fork location like this...
 
 **1. Fork the correct repo (the Thoth Tech one) via the GitHub web interface**
 

--- a/docs/learning/training/configuring-jenkins.md
+++ b/docs/learning/training/configuring-jenkins.md
@@ -4,10 +4,12 @@
 
 This guide is for how to download and install Jenkins and how to run on GCP (GCP is not yet added)
 
-- Running Jenkins locally to get a good idea of how it works. Should be run using Docker as this is how it will run when in GCP
+- Running Jenkins locally to get a good idea of how it works. Should be run using Docker as this is
+  how it will run when in GCP
 - Hosting it on GCP, through either Cloud Run or Google Kubernetes Engine (GKE)
 - Connecting our GitHub repo and configuring how the builds will work
-- The auth team will need to work out how to authenticate on Jenkins. Since the URL will be publically exposed obviously we don't want anyone with the URL to have access.
+- The auth team will need to work out how to authenticate on Jenkins. Since the URL will be
+  publically exposed obviously we don't want anyone with the URL to have access.
 
 ## How to run Jenkins locally
 
@@ -20,8 +22,13 @@ Prerequisites
 Steps to install and run
 
 1. Run the follow command to pull jenkins to your local registry `docker pull jenkins/jenkins`
-2. Run and expose the container with the following command `docker run -d -v jenkins_home:/var/jenkins_home -p 8080:8080 -p 50000:50000 --restart always jenkins/jenkins` If you go to `localhost:8080` in a web browser you'll see Jenkins running
-3. You need to grab the password that is within the container, the easiest option is use `docker logs container_id` After running this command you will see the passsword within the logs, it's pretty easy to find. You can find the container id by going to the Docker GUI and going to the container section, you'll see it running.
+2. Run and expose the container with the following command
+   `docker run -d -v jenkins_home:/var/jenkins_home -p 8080:8080 -p 50000:50000 --restart always jenkins/jenkins`
+   If you go to `localhost:8080` in a web browser you'll see Jenkins running
+3. You need to grab the password that is within the container, the easiest option is use
+   `docker logs container_id` After running this command you will see the passsword within the logs,
+   it's pretty easy to find. You can find the container id by going to the Docker GUI and going to
+   the container section, you'll see it running.
 4. Enter the password and then you can start using Jenkins.
 
 **Jenkins running locally on my machine**

--- a/docs/learning/training/developing-with-wsl2.md
+++ b/docs/learning/training/developing-with-wsl2.md
@@ -2,14 +2,18 @@
 
 ## What is WSL and why would I want to use it?
 
-In web development, the Windows operating system is notorious for causing issues. That's why it is recommended that all Windows users who are developing on Thoth Tech web repositories use Windows Subsystem for Linux.
-Windows Subsystem for Linux (WSL) allows Linux distributions to run within the Windows OS. This greatly simplifies development, and it is luckily very easy to set up!
+In web development, the Windows operating system is notorious for causing issues. That's why it is
+recommended that all Windows users who are developing on Thoth Tech web repositories use Windows
+Subsystem for Linux. Windows Subsystem for Linux (WSL) allows Linux distributions to run within the
+Windows OS. This greatly simplifies development, and it is luckily very easy to set up!
 
 ## Step 1: Set up WSL2
 
-To quickly [set up WSL2 with Ubuntu](https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-10#1-overview):
+To quickly
+[set up WSL2 with Ubuntu](https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-10#1-overview):
 
-1. Run Windows PowerShell as administrator (search "Powershell" in the windows search bar and right-click 'run as administrator') and use the following command:
+1. Run Windows PowerShell as administrator (search "Powershell" in the windows search bar and
+   right-click 'run as administrator') and use the following command:
 
    ```powershell
    wsl --install -d ubuntu
@@ -19,9 +23,11 @@ To quickly [set up WSL2 with Ubuntu](https://ubuntu.com/tutorials/install-ubuntu
 
 2. Restart your computer.
 
-3. Open Ubuntu (search "Ubuntu" in the windows search bar) and follow the first time setup instructions to create a username and password.
+3. Open Ubuntu (search "Ubuntu" in the windows search bar) and follow the first time setup
+   instructions to create a username and password.
 
-   **NOTE: If you experience errors during this step, it may be because virtualization is disabled in your BIOS. To fix this will be different depending on your computer/CPU.**
+   **NOTE: If you experience errors during this step, it may be because virtualization is disabled
+   in your BIOS. To fix this will be different depending on your computer/CPU.**
 
 4. To make sure you have the latest updates for Ubuntu, use the following commands:
    ```shell
@@ -35,13 +41,16 @@ To quickly [set up WSL2 with Ubuntu](https://ubuntu.com/tutorials/install-ubuntu
 
 ## Step 2: If your project requires Docker, it is best to download and install Docker Desktop now (ignore this step if not using Docker)
 
-Docker Desktop is a software that is used to simplify the development of Doubtfire/OnTrack and other Thoth Tech projects. Docker removes the need to install native tools used within the project.
+Docker Desktop is a software that is used to simplify the development of Doubtfire/OnTrack and other
+Thoth Tech projects. Docker removes the need to install native tools used within the project.
 
-1. Download Docker Desktop from the [Docker website](https://docs.docker.com/desktop/windows/install/).
+1. Download Docker Desktop from the
+   [Docker website](https://docs.docker.com/desktop/windows/install/).
 
 ## Step 3: Create a directory for Thoth Tech development
 
-Open up your Ubuntu WSL2 terminal and create a directory to organise your Thoth Tech projects. In this case we could create a directory for all Thoth Tech repositories
+Open up your Ubuntu WSL2 terminal and create a directory to organise your Thoth Tech projects. In
+this case we could create a directory for all Thoth Tech repositories
 
 ```shell
 mkdir thoth-tech
@@ -53,20 +62,24 @@ Then, cd into the newly created directory
 cd thoth-tech
 ```
 
-Now we can clone a Thoth Tech repository in this directory. If we were working on OnTrack, we can now use `git clone` to download a local version of the repository. Follow the [OnTrack contributing guide]() for more information.
+Now we can clone a Thoth Tech repository in this directory. If we were working on OnTrack, we can
+now use `git clone` to download a local version of the repository. Follow the
+[OnTrack contributing guide]() for more information.
 
 ## Step 4. Developing using Visual Studio Code
 
-Developing in WSL2 is extremely easy using Visual Studio Code.
-After creating a new branch for your project (following the [Thoth Tech git contribution guide]()), it is as simple as typing
+Developing in WSL2 is extremely easy using Visual Studio Code. After creating a new branch for your
+project (following the [Thoth Tech git contribution guide]()), it is as simple as typing
 
 ```shell
 code .
 ```
 
-This will open Visual Studio Code in the directory that you are currently in.
-If prompted to install any recommended extensions (for example, "WSL - Remote"), you should do so.
+This will open Visual Studio Code in the directory that you are currently in. If prompted to install
+any recommended extensions (for example, "WSL - Remote"), you should do so.
 
-Once VS Code is open, you will have access to the full codebase of the project and be able to make changes.
+Once VS Code is open, you will have access to the full codebase of the project and be able to make
+changes.
 
-Once you are happy with your changes, you can refer again to Thoth Tech git contribution guide for creating a pull request to merge with the main project.
+Once you are happy with your changes, you can refer again to Thoth Tech git contribution guide for
+creating a pull request to merge with the main project.

--- a/docs/learning/training/distinction-high-distinction-workshop.md
+++ b/docs/learning/training/distinction-high-distinction-workshop.md
@@ -4,15 +4,20 @@
 
 ### Pass
 
-To pass, show achievement of your course outcomes and demonstrate the ability to assist with the team's work.
+To pass, show achievement of your course outcomes and demonstrate the ability to assist with the
+team's work.
 
-At this level, you will assist in building the pieces needed by your team to complete the puzzle. It would help if you had support to complete your work to an acceptable standard or get the tasks done on time.
+At this level, you will assist in building the pieces needed by your team to complete the puzzle. It
+would help if you had support to complete your work to an acceptable standard or get the tasks done
+on time.
 
 ### Credit
 
 Show you are a responsible team member to receive a credit.
 
-At this leve you will be buliding the pieces needed by your team to complete the puzzle. You work at this level if you are a responsible team member. You can follow instructions from your lead and deliver the designated work at an acceptable standard in the allocated timeframe. You must show:
+At this leve you will be buliding the pieces needed by your team to complete the puzzle. You work at
+this level if you are a responsible team member. You can follow instructions from your lead and
+deliver the designated work at an acceptable standard in the allocated timeframe. You must show:
 
 - Clear contributions to your project
 - Be engaged and Present
@@ -22,7 +27,10 @@ At this leve you will be buliding the pieces needed by your team to complete the
 
 Showcase your leadership in the team and a cohort for distinction.
 
-At this level you will be building a puzzle. Your team members will build the pieces needed but you need to provide adequate guidance and support to make sure the pieces are those needed. You work at this level if you can demonstrate leaderhsip within you team and support the vision of the company directors. You must show:
+At this level you will be building a puzzle. Your team members will build the pieces needed but you
+need to provide adequate guidance and support to make sure the pieces are those needed. You work at
+this level if you can demonstrate leaderhsip within you team and support the vision of the company
+directors. You must show:
 
 - Credit+ contributions
 - Leadership
@@ -32,31 +40,34 @@ At this level you will be building a puzzle. Your team members will build the pi
 
 Showcase excellent and outstanding achievements for high distinction.
 
-At this level you need to demonstrate how you have shown excellence in what you have achieved in the capstone program. You want to demonstrate how your leadership helped shape the company, and your cohort interactions helped develop students across the program. YOu will be able to articulate the aspects of your performance that demonstrate excellence in leading people, technical expertise, communication skills, quality of work and/or level of achievement. You must show:
+At this level you need to demonstrate how you have shown excellence in what you have achieved in the
+capstone program. You want to demonstrate how your leadership helped shape the company, and your
+cohort interactions helped develop students across the program. YOu will be able to articulate the
+aspects of your performance that demonstrate excellence in leading people, technical expertise,
+communication skills, quality of work and/or level of achievement. You must show:
 
 - Distinction+ contributions
 - Excellence
 
 ## Talking Points:
 
-⁃ The idea of this capstone is to run like an actual company to give as close to real world as possible
-⁃ Do not wait to be told what to do, find things to do - show initiative
-⁃ Not just what you do, but how you communicate it; evidence, engagement, retrospective
-⁃ Make sure you regularly read the rubric and self-identify opportunities
-⁃ Make sure you are familiar with your Course Learning Outcomes
-⁃ Reach out to your delivery lead, product lead or area leads if you want feedback on ideas or have questions
-⁃ Supporting your delivery leads – ask if they would like to delegate you something?
-⁃ How are you supporting your project members? Are they confident? How are you supporting the wider company team?
-⁃ What skills do you have? What are you confident in? - support your team, consult with other project groups
+⁃ The idea of this capstone is to run like an actual company to give as close to real world as
+possible ⁃ Do not wait to be told what to do, find things to do - show initiative ⁃ Not just what
+you do, but how you communicate it; evidence, engagement, retrospective ⁃ Make sure you regularly
+read the rubric and self-identify opportunities ⁃ Make sure you are familiar with your Course
+Learning Outcomes ⁃ Reach out to your delivery lead, product lead or area leads if you want feedback
+on ideas or have questions ⁃ Supporting your delivery leads – ask if they would like to delegate you
+something? ⁃ How are you supporting your project members? Are they confident? How are you supporting
+the wider company team? ⁃ What skills do you have? What are you confident in? - support your team,
+consult with other project groups
 
 ## Contributions:
 
-⁃ Invest in other people’s development - hype team contributions in retrospectives – what you have done but also supporting other team members
-⁃ Feedback conversations - shout out channel - not just for leadership to use
-⁃ Identify opportunities and pioneer something
-⁃ Handbook contributions
-⁃ Documentation - moving everything towards git
-⁃ Get creative
-⁃ Run a workshop? Make a how to video? Post about an ‘aha’ moment, share resources, start a committee? Connect with people in other companies doing similar things
-⁃ Cohort contributions - are you engaging? Sharing things that you have learnt?
-⁃ What do you want to work towards? Do you want to be a leader next trimester? How are you trying to achieve that? Who do you need to communicate with?
+⁃ Invest in other people’s development - hype team contributions in retrospectives – what you have
+done but also supporting other team members ⁃ Feedback conversations - shout out channel - not just
+for leadership to use ⁃ Identify opportunities and pioneer something ⁃ Handbook contributions ⁃
+Documentation - moving everything towards git ⁃ Get creative ⁃ Run a workshop? Make a how to video?
+Post about an ‘aha’ moment, share resources, start a committee? Connect with people in other
+companies doing similar things ⁃ Cohort contributions - are you engaging? Sharing things that you
+have learnt? ⁃ What do you want to work towards? Do you want to be a leader next trimester? How are
+you trying to achieve that? Who do you need to communicate with?

--- a/docs/learning/training/index.md
+++ b/docs/learning/training/index.md
@@ -1,6 +1,7 @@
 # Training List
 
-Thoth Tech believes in educating our employees. As such we provide training material to assist with technical development.
+Thoth Tech believes in educating our employees. As such we provide training material to assist with
+technical development.
 
 A list of training can be seen below:
 

--- a/docs/learning/training/markdown-guide.md
+++ b/docs/learning/training/markdown-guide.md
@@ -8,8 +8,9 @@
 
 ## What is Markdown?
 
-Markdown (`.md`) is a markup language, similar to a `.txt` file, but with basic **in-text** formating
-elements. Although it can produce similar outputs as a word processor, there are other benefits that Thoth Tech can leverage.
+Markdown (`.md`) is a markup language, similar to a `.txt` file, but with basic **in-text**
+formating elements. Although it can produce similar outputs as a word processor, there are other
+benefits that Thoth Tech can leverage.
 
 ### Thoth Tech and Markdown
 
@@ -33,7 +34,8 @@ It's simple to specify a file as Markdown. Simply name it with the extension `.m
 
 ### How do I format a Markdown file?
 
-[The Markdown Guide](https://www.markdownguide.org) is an excellent online resource providing at-a-glance formatting examples.
+[The Markdown Guide](https://www.markdownguide.org) is an excellent online resource providing
+at-a-glance formatting examples.
 
 Commonly used formatting options include the following:
 
@@ -57,10 +59,11 @@ Commonly used formatting options include the following:
 
 ### Diagrams
 
-You can generate diagrams and flowcharts from text by using [Mermaid](https://mermaid-js.github.io/mermaid/#/).
+You can generate diagrams and flowcharts from text by using
+[Mermaid](https://mermaid-js.github.io/mermaid/#/).
 
-The [Mermaid Live Editor](https://mermaid-js.github.io/mermaid-live-editor/) helps you learn Mermaid and debug
-issues in your Mermaid code. Use it to identify and resolve issues in your diagrams.
+The [Mermaid Live Editor](https://mermaid-js.github.io/mermaid-live-editor/) helps you learn Mermaid
+and debug issues in your Mermaid code. Use it to identify and resolve issues in your diagrams.
 
 To generate a diagram or flowchart, write your text inside the mermaid block:
 
@@ -84,8 +87,8 @@ graph TD
 
 #### Collapse
 
-A collapsed content section is used to hide information until a user chooses to reveal it with a click or tap on the summary text.
-The hidden content is revealed inline. For example, this code:
+A collapsed content section is used to hide information until a user chooses to reveal it with a
+click or tap on the summary text. The hidden content is revealed inline. For example, this code:
 
 ```markdown
 <details>
@@ -119,13 +122,15 @@ VS Code has built in support for previewing Markdown files.
 
 To open your **current tab** in **Markdown preview**, use _shift + command + v_.
 
-To create a **split screen view** (allowing you to edit your Markdown file in one screen while previewing in another, side-by-side), press _command + k_, release the keys, then press _v_.
+To create a **split screen view** (allowing you to edit your Markdown file in one screen while
+previewing in another, side-by-side), press _command + k_, release the keys, then press _v_.
 
 ### Windows Users
 
 To open your **current tab** in **Markdown preview**, use _shift + ctrl + v_.
 
-To create a **split screen view** (allowing you to edit your Markdown file in one screen while previewing in another, side-by-side), press _ctrl + k_, release the keys, then press _v_.
+To create a **split screen view** (allowing you to edit your Markdown file in one screen while
+previewing in another, side-by-side), press _ctrl + k_, release the keys, then press _v_.
 
 ## Markdown Templates
 

--- a/docs/learning/training/trello-guide.md
+++ b/docs/learning/training/trello-guide.md
@@ -12,21 +12,33 @@
 
 ## What is Trello?
 
-Trello is a visual tool for work management that champions collaboration and organisation on projects.
+Trello is a visual tool for work management that champions collaboration and organisation on
+projects.
 
 ### Workspaces vs Boards?
 
-When using Trello, you will come across terms such as Workspaces and Boards. A workspace represents the overarching team/department/product you work within or on. At Thoth Tech, our workspaces are represented by the product you are working on (eg SplashKit). Each workspace contains one or more boards within. Boards are used to represent projects or teams within the workspace. Thoth Tech divides their boards into teams.
+When using Trello, you will come across terms such as Workspaces and Boards. A workspace represents
+the overarching team/department/product you work within or on. At Thoth Tech, our workspaces are
+represented by the product you are working on (eg SplashKit). Each workspace contains one or more
+boards within. Boards are used to represent projects or teams within the workspace. Thoth Tech
+divides their boards into teams.
 
 #### **How to navigate Workspaces and Boards**
 
-Workspaces can be found and navigated under the "Workspaces" tab at the top left of the screen. A drop-down list will appear with all the workspaces you are a member of.
+Workspaces can be found and navigated under the "Workspaces" tab at the top left of the screen. A
+drop-down list will appear with all the workspaces you are a member of.
 
-To access boards, you need to select a workspace. You can view a list of the boards within a workspace by selecting the "Boards" tab on the left hand side menu. Below this is the My Boards section. It will show the boards that you are a member of within the current workspace.
+To access boards, you need to select a workspace. You can view a list of the boards within a
+workspace by selecting the "Boards" tab on the left hand side menu. Below this is the My Boards
+section. It will show the boards that you are a member of within the current workspace.
 
 #### **How to Favourite boards**
 
-In the "My Boards" section of the left menu, you can favourite boards that you use most often. These will be pushed to the top of this list. Favourite boards can be accessed regardless of which workspace you have currently selected. This is done by selecting the "Starred" option on the top menu. Favouriting allows for quick navigation between your active projects. This is handy when you have joined a large number of boards across multiple workspaces.
+In the "My Boards" section of the left menu, you can favourite boards that you use most often. These
+will be pushed to the top of this list. Favourite boards can be accessed regardless of which
+workspace you have currently selected. This is done by selecting the "Starred" option on the top
+menu. Favouriting allows for quick navigation between your active projects. This is handy when you
+have joined a large number of boards across multiple workspaces.
 
 ---
 
@@ -48,107 +60,168 @@ The main form for cards within Thoth Tech's boards will be as tasks.
 There are three ways to move a card on a board.
 
 1. Drag and drop a card into the desired column.
-2. Hover over the card until the edit pencil appears. From here you can select "Move", and choose the board, column and position you want to move it to
-3. Open the card to view all its details. On the right hand side menu, you can find the "Move" option under the "Actions" header. Select "Move", and choose the board, column and position you want to move it to
+2. Hover over the card until the edit pencil appears. From here you can select "Move", and choose
+   the board, column and position you want to move it to
+3. Open the card to view all its details. On the right hand side menu, you can find the "Move"
+   option under the "Actions" header. Select "Move", and choose the board, column and position you
+   want to move it to
 
 ### When do I move a card?
 
-A card can be moved for multiple reasons. It can be moved from the backlog into the current sprint, it can be moved when you pick it up to work on it and again when you finish your work on it.
+A card can be moved for multiple reasons. It can be moved from the backlog into the current sprint,
+it can be moved when you pick it up to work on it and again when you finish your work on it.
 
 ### How can I monitor a card's progress?
 
-An easy way to monitor a card is to subscribe to notifications for the card. There are two ways to do this. You can open a card and press "Join", but this should only be done if you are actively working on a card. To get notifications without joining a card, you can select "Watch" which is under the "Action" header on the right hand side of the card.
+An easy way to monitor a card is to subscribe to notifications for the card. There are two ways to
+do this. You can open a card and press "Join", but this should only be done if you are actively
+working on a card. To get notifications without joining a card, you can select "Watch" which is
+under the "Action" header on the right hand side of the card.
 
 ### What do I write for a description?
 
-A description should succinctly tell anyone who could pick up the card its background, knowledge and resources required, steps on how to complete it and its definition of done. You should be able to read a card's description and immediately be able to action it.
+A description should succinctly tell anyone who could pick up the card its background, knowledge and
+resources required, steps on how to complete it and its definition of done. You should be able to
+read a card's description and immediately be able to action it.
 
 ### What do I put in the Activity section?
 
-The activity section keeps track of all changes made to a card. It will show edits, comments and moves from column to column. Comments should be added when issues arise, when new information is found, or if you need to clarify something with your delivery lead/colleagues. Often this will be utilised during the testing phase. If a test fails, the tester can leave details of the issue on the card and reassign it to the developer, allowing them to input the neccessary changes.
+The activity section keeps track of all changes made to a card. It will show edits, comments and
+moves from column to column. Comments should be added when issues arise, when new information is
+found, or if you need to clarify something with your delivery lead/colleagues. Often this will be
+utilised during the testing phase. If a test fails, the tester can leave details of the issue on the
+card and reassign it to the developer, allowing them to input the neccessary changes.
 
 ### Card templates
 
-For cards that have similar structure or tasks that will be repeated over and over, you can create a card and designate it as a template. By writing cards in a formulaic or structured way, it allows you to create multiple cards with the same elaborate structures by copying the template and altering smaller details. A card can be designated as a template by ticking the "Template" option under the "Action" header on the right hand side menu.
+For cards that have similar structure or tasks that will be repeated over and over, you can create a
+card and designate it as a template. By writing cards in a formulaic or structured way, it allows
+you to create multiple cards with the same elaborate structures by copying the template and altering
+smaller details. A card can be designated as a template by ticking the "Template" option under the
+"Action" header on the right hand side menu.
 
 ## Skills/Features
 
 ### Assign People to Cards
 
-Member assignment to Trello cards allows team members and the delivery lead to know who is currently working on a specific card or task. This makes it easier to determine who to contact if new information arises for a task or if a specific card is a blocker for your own current card.
+Member assignment to Trello cards allows team members and the delivery lead to know who is currently
+working on a specific card or task. This makes it easier to determine who to contact if new
+information arises for a task or if a specific card is a blocker for your own current card.
 
 To assign a person to a card, select the card you want to assign the person to bring up its details.
 
 #### **If assigning yourself**
 
-Navigate to the menu on the right hand side of the card, select "Join". Your initials should appear at the top of the card next to the "Members" header.
+Navigate to the menu on the right hand side of the card, select "Join". Your initials should appear
+at the top of the card next to the "Members" header.
 
 #### **If assigning someone else:**
 
-Navigate to the menu on the right hand side of the card, select "Members". In the search box, search the name of the team member you would like to add. Select their name. Their initials should appear at the top of the card next to the "Members" header.
+Navigate to the menu on the right hand side of the card, select "Members". In the search box, search
+the name of the team member you would like to add. Select their name. Their initials should appear
+at the top of the card next to the "Members" header.
 
 ### Create and Assign Labels
 
-Labels are a handy tool within Trello that allow you to add context to a card. These labels could represent the projects being undertaken on the board, the semester/time that the work is expected to be undertaken, or anything that you think is required to be categorised.
+Labels are a handy tool within Trello that allow you to add context to a card. These labels could
+represent the projects being undertaken on the board, the semester/time that the work is expected to
+be undertaken, or anything that you think is required to be categorised.
 
 #### **Creating Labels**
 
-At the top of the Trello board, there are some tabs that run to the right hand side of the board. The furthest right tab is labelled "Show menu". Selecting this will bring up a menu with additional functions.
+At the top of the Trello board, there are some tabs that run to the right hand side of the board.
+The furthest right tab is labelled "Show menu". Selecting this will bring up a menu with additional
+functions.
 
-Select "More". An option for "Labels" will appear. Pressing this will show six default colours. Selecting the edit pencil will allow you to add a title to the label.
+Select "More". An option for "Labels" will appear. Pressing this will show six default colours.
+Selecting the edit pencil will allow you to add a title to the label.
 
-If all 6 colours are in use, select "Create a new label". This will give you options for 4 other colours or to double up on a colour (not recommended). You can also create a label without a colour. It will not appear on the board but can be viewed when the card is selected.
+If all 6 colours are in use, select "Create a new label". This will give you options for 4 other
+colours or to double up on a colour (not recommended). You can also create a label without a colour.
+It will not appear on the board but can be viewed when the card is selected.
 
 #### Assigning Labels
 
-Hover over the card that you want to assign a label to and select the edit pencil icon. An option to "Edit Labels" will appear. Selecting this will bring up the "Labels" menu as shown above. Here you can assign pre-made labels or create a new one.
+Hover over the card that you want to assign a label to and select the edit pencil icon. An option to
+"Edit Labels" will appear. Selecting this will bring up the "Labels" menu as shown above. Here you
+can assign pre-made labels or create a new one.
 
 ### Setting Up Columns
 
-Creating a column is quite simple. At the top of the board there is an option to "Add a list". Enter the title for the column and save. You can create as many columns as you like.
+Creating a column is quite simple. At the top of the board there is an option to "Add a list". Enter
+the title for the column and save. You can create as many columns as you like.
 
-There is no set way to organise columns within an Agile framework. The basic three columns you need are:
+There is no set way to organise columns within an Agile framework. The basic three columns you need
+are:
 
 - To Do
 - In Progress
 - Completed
 
-At Thoth Tech, we recommend adding a few extra columns to ensure that the board is more informative, and easier to use. Here is the list of columns that are recommended, in order:
+At Thoth Tech, we recommend adding a few extra columns to ensure that the board is more informative,
+and easier to use. Here is the list of columns that are recommended, in order:
 
 - Epic
-  - Cards in this column should break down the epic for each project, using the Epic Markdown Template to set up. These cards should never be moved.
+  - Cards in this column should break down the epic for each project, using the Epic Markdown
+    Template to set up. These cards should never be moved.
 - User Stories
-  - All user stories extracted from each epic should be located in this column. These cards should only be moved once the user story is completely exhausted.
+  - All user stories extracted from each epic should be located in this column. These cards should
+    only be moved once the user story is completely exhausted.
 - Product Backlog
-  - All the tasks extracted from the user stories belong in this column. They will remain there until they have been added to a new sprint in a sprint planning session.
+  - All the tasks extracted from the user stories belong in this column. They will remain there
+    until they have been added to a new sprint in a sprint planning session.
 - Sprint Backlog
   - Contains all cards that have been planned to be completed in the current sprint.
 - In Progress/Doing
-  - When a team member assigns themselves to a card, it should be moved into this column. It remains in this column until the task is completed.
+  - When a team member assigns themselves to a card, it should be moved into this column. It remains
+    in this column until the task is completed.
 - Done
-  - Cards in this column have been completed, waiting on testing/review to be completed. This column acts as a buffer, which makes it easier to see which cards need testing and when a card is no longer in progress. When in the done column, the card should have its member unassigned.
+  - Cards in this column have been completed, waiting on testing/review to be completed. This column
+    acts as a buffer, which makes it easier to see which cards need testing and when a card is no
+    longer in progress. When in the done column, the card should have its member unassigned.
 - Testing/Review
-  - Cards in this column have been picked up to ensure the quality of work and that it is coherent, documented and works properly. If everything is good and the delivery lead is happy, the card can be moved to the completed column. If the card is not ready or needs work, comments are to be left in the activity section on how to fix. Then the card needs to be moved back to in progress and assigned to the original team member working on it. It is good practice to never have the same person testing a card that they developed, just to ensure transparency.
+  - Cards in this column have been picked up to ensure the quality of work and that it is coherent,
+    documented and works properly. If everything is good and the delivery lead is happy, the card
+    can be moved to the completed column. If the card is not ready or needs work, comments are to be
+    left in the activity section on how to fix. Then the card needs to be moved back to in progress
+    and assigned to the original team member working on it. It is good practice to never have the
+    same person testing a card that they developed, just to ensure transparency.
 - Blocked
-  - This column is where cards are to be moved if major issues are found or they are waiting on work within another card to be completed. This column is of high priority and ideally needs to be actioned immediately.
+  - This column is where cards are to be moved if major issues are found or they are waiting on work
+    within another card to be completed. This column is of high priority and ideally needs to be
+    actioned immediately.
 - Completed
   - All tasks that are successfully completed should be in this column.
 
 ### Adding Checklists to Cards
 
-Checklists are a simple way to track progress of a task as they show how many subtasks have been completed for each task. This progress will appear in the bottom left corner of a card when looking at the board.
+Checklists are a simple way to track progress of a task as they show how many subtasks have been
+completed for each task. This progress will appear in the bottom left corner of a card when looking
+at the board.
 
-To attach a checklist to a card, select the card and navigate to the menu on the right hand side. The third option under the "Add to card" header is "Checklists". Selecting this allows you to title the checklist, and to automatically populate the checklist if it is the same as a checklist on another card.
+To attach a checklist to a card, select the card and navigate to the menu on the right hand side.
+The third option under the "Add to card" header is "Checklists". Selecting this allows you to title
+the checklist, and to automatically populate the checklist if it is the same as a checklist on
+another card.
 
-From here, a checklist header will appear in the main section of the card above "Activity". Select the "Add an item" button, which will allow you to create a new item for the checklist. There is no limit on number of items to add to a checklist, but if a task has too many subtasks, consider either breaking the task down or turning the task into a new user story.
+From here, a checklist header will appear in the main section of the card above "Activity". Select
+the "Add an item" button, which will allow you to create a new item for the checklist. There is no
+limit on number of items to add to a checklist, but if a task has too many subtasks, consider either
+breaking the task down or turning the task into a new user story.
 
 ### Adding Attachments
 
-You can attach images, UML diagrams, Trello cards and many other items to a Trello Card. This gives a card greater context. To add an attachment, select the target card and go to the menu on the right hand side. Under "Add to card" you will find an option for "Attachments". From here, select where the attachment you want to add is currently located. This will prompt you to browse for and select your desired item to attach. Attached items will appear just below the description of the card.
+You can attach images, UML diagrams, Trello cards and many other items to a Trello Card. This gives
+a card greater context. To add an attachment, select the target card and go to the menu on the right
+hand side. Under "Add to card" you will find an option for "Attachments". From here, select where
+the attachment you want to add is currently located. This will prompt you to browse for and select
+your desired item to attach. Attached items will appear just below the description of the card.
 
 ### Adding Stickers to Cards
 
-You can personalise your board by using stickers. By selecting the "Show menu" option at the top right of the page, you will find an option for stickers. There are pre-loaded stickers to be used, as well as options to add your own images and GIFs to be used as stickers on your board.
+You can personalise your board by using stickers. By selecting the "Show menu" option at the top
+right of the page, you will find an option for stickers. There are pre-loaded stickers to be used,
+as well as options to add your own images and GIFs to be used as stickers on your board.
 
 ### How To Link Cards
 
@@ -158,33 +231,62 @@ TBC
 
 ## Power-ups (Plugins):
 
-When you select a card, there is an option to add Power-ups. These are extra tools that you can utilise to better streamline your board and the Agile process. Below are two popular examples of Power-ups that you can utilise, but there are many more that can be accessed and utilised.
+When you select a card, there is an option to add Power-ups. These are extra tools that you can
+utilise to better streamline your board and the Agile process. Below are two popular examples of
+Power-ups that you can utilise, but there are many more that can be accessed and utilised.
 
 ### Agile
 
-There are two Power-ups that are recommended to use within your Trello board to make it more Agile. Corello have created a Power-up called `Agile Tools` which allows Story Points to be added to cards, whilst the Power-up `Limit Lists` allows a team to set work in progress limits on columns.
+There are two Power-ups that are recommended to use within your Trello board to make it more Agile.
+Corello have created a Power-up called `Agile Tools` which allows Story Points to be added to cards,
+whilst the Power-up `Limit Lists` allows a team to set work in progress limits on columns.
 
-To install a Power-up, select the Power-ups menu option at the top of your Trello board. This will show all your current installed Power-ups and allow you to add more by selecting the option `Add Power-ups`. Use the search function to look for different tools you can utilise within your Trello board.
+To install a Power-up, select the Power-ups menu option at the top of your Trello board. This will
+show all your current installed Power-ups and allow you to add more by selecting the option
+`Add Power-ups`. Use the search function to look for different tools you can utilise within your
+Trello board.
 
 #### **Story Points**
 
-Story Points are an important facet of an Agile development style, as they give context to how much work is required, how difficult a card is, or how long a card will take to complete. There is no hard or fast rule on how to set Story Points, but they are required to successfully plan a sprint.
+Story Points are an important facet of an Agile development style, as they give context to how much
+work is required, how difficult a card is, or how long a card will take to complete. There is no
+hard or fast rule on how to set Story Points, but they are required to successfully plan a sprint.
 
-A good idea to get started with Story points is to have each point represent an amount of time. Each number can represent a length of time (1 = 1 hour or 1 day, 2 = 2 hours etc), or even represent a range of times (1 = 1 to 2 hours work, 2 = 2 to 5 hours work). It is important set these story points at the start of the development process. There is scope to alter them if they aren't relevant or need work, but they should not be changed all the time or on a whim.
+A good idea to get started with Story points is to have each point represent an amount of time. Each
+number can represent a length of time (1 = 1 hour or 1 day, 2 = 2 hours etc), or even represent a
+range of times (1 = 1 to 2 hours work, 2 = 2 to 5 hours work). It is important set these story
+points at the start of the development process. There is scope to alter them if they aren't relevant
+or need work, but they should not be changed all the time or on a whim.
 
-The information on how your teams story points work needs to be easily accessible and clear, to ensure tasks are given the correct amount of time to complete.
+The information on how your teams story points work needs to be easily accessible and clear, to
+ensure tasks are given the correct amount of time to complete.
 
-Once you install `Agile Tools`, Story Points can be set by selecting a card and navigating to the `Power-ups` heading on the right hand side of the card. A default scale of Story Points will appear in the form of a Fibonacci sequence (1, 2, 3, 5, 8, 13, 21). As the numbers increase, the difficulty or time should increase. Set the card to the Story Point level you have discussed within your Sprint planning session.
+Once you install `Agile Tools`, Story Points can be set by selecting a card and navigating to the
+`Power-ups` heading on the right hand side of the card. A default scale of Story Points will appear
+in the form of a Fibonacci sequence (1, 2, 3, 5, 8, 13, 21). As the numbers increase, the difficulty
+or time should increase. Set the card to the Story Point level you have discussed within your Sprint
+planning session.
 
 #### **List Limits**
 
-Adding List Limits to columns on a Trello board is an effective way to ensure that the team is utilising Agile practices and completes work efficiently.
+Adding List Limits to columns on a Trello board is an effective way to ensure that the team is
+utilising Agile practices and completes work efficiently.
 
-Often a team will find most of their members are comfortable with either the developing or the testing side of the development cycle. This can lead to bottlenecks during a sprint where work is not reaching a specific column because either too much is being started or there is a lack of people picking up cards. Work in progress caps can alleviate these bottlenecks.
+Often a team will find most of their members are comfortable with either the developing or the
+testing side of the development cycle. This can lead to bottlenecks during a sprint where work is
+not reaching a specific column because either too much is being started or there is a lack of people
+picking up cards. Work in progress caps can alleviate these bottlenecks.
 
-By setting a limit to how many cards can be in the done column, you force people to start picking up those cards and testing them. This ensures that tasks consistently get developed to completion. These limits will depend on how many members are on your team and how you define the roles, but should be constantly discussed in planning meetings and retrospectives to reach an optimal value.
+By setting a limit to how many cards can be in the done column, you force people to start picking up
+those cards and testing them. This ensures that tasks consistently get developed to completion.
+These limits will depend on how many members are on your team and how you define the roles, but
+should be constantly discussed in planning meetings and retrospectives to reach an optimal value.
 
-Once the Power-up `List Limits` is installed, list limits can be set on a column byselecting the `...` at the top right of the column and navigating down to `Set list limit`. This allows you to set individual limits on cards within a column. Although you can still place cards in the column, as soon as its full you should be actioning the cards within to remove them. Each list can have a different limit within it.
+Once the Power-up `List Limits` is installed, list limits can be set on a column byselecting the
+`...` at the top right of the column and navigating down to `Set list limit`. This allows you to set
+individual limits on cards within a column. Although you can still place cards in the column, as
+soon as its full you should be actioning the cards within to remove them. Each list can have a
+different limit within it.
 
 ---
 

--- a/docs/learning/training/writing-documentation.md
+++ b/docs/learning/training/writing-documentation.md
@@ -17,11 +17,14 @@
 
 ## What is Documentation
 
-> “Documentation is one of the most important parts of a software project” – Eric Holscher, co-founder of Write the Docs.
+> “Documentation is one of the most important parts of a software project” – Eric Holscher,
+> co-founder of Write the Docs.
 
-Documentation is official information provided by the company for our users and contributors. It is the preferred method of technical support and should provide instant clarity for many issues.
+Documentation is official information provided by the company for our users and contributors. It is
+the preferred method of technical support and should provide instant clarity for many issues.
 
-Within Thoth Tech, all documentation will be written in markdown. You can find the guide [here](markdown-guide.md).
+Within Thoth Tech, all documentation will be written in markdown. You can find the guide
+[here](markdown-guide.md).
 
 ### Why is Documentation important?
 
@@ -32,8 +35,9 @@ Without documentation there is no record of:
 - What processes are
 - How users use the tool
 
-**Consider:**
-As a new recruit to Thoth Tech, wouldn’t you have loved documents on how to install, set up, and contribute to our Products? Or easy to access guidance on what features were to be created, improved, or removed?
+**Consider:** As a new recruit to Thoth Tech, wouldn’t you have loved documents on how to install,
+set up, and contribute to our Products? Or easy to access guidance on what features were to be
+created, improved, or removed?
 
 ### Who uses documentation?
 
@@ -41,7 +45,8 @@ The type of document can affect who uses it.
 
 Thus, it is important to think about the intended audience of when writing documentation.
 
-**Consider:** If a tool is made for primary school children odds are they won’t know what the #FFFFFF coloured button is.
+**Consider:** If a tool is made for primary school children odds are they won’t know what the
+#FFFFFF coloured button is.
 
 The people who will use Thoth Tech documents are:
 
@@ -76,20 +81,16 @@ The people who will use Thoth Tech documents are:
 
 ## Goals of Documentation
 
-**Empower:**
-We want our people to have the knowledge to make the most of our products
+**Empower:** We want our people to have the knowledge to make the most of our products
 
-**Respect:**
-We want our people to feel included and accepted for who they are
+**Respect:** We want our people to feel included and accepted for who they are
 
-**Educate:**
-We want to assist our people in their learning and provide them with the information they need
+**Educate:** We want to assist our people in their learning and provide them with the information
+they need
 
-**Guide:**
-We want to lead our people in a thoughtful manner towards their goals
+**Guide:** We want to lead our people in a thoughtful manner towards their goals
 
-**Honest:**
-We want to be truthful to our people and focus on our real strengths
+**Honest:** We want to be truthful to our people and focus on our real strengths
 
 ---
 
@@ -129,7 +130,8 @@ In **passive voice**, the subject of the sentence has the action done to it.
 
 > **Yes:** Marti logged into the account.<div> **No:** The account was logged into by Marti.
 
-_One exception_ is when you want to specifically emphasize the action over the subject. In some cases, this is fine.
+_One exception_ is when you want to specifically emphasize the action over the subject. In some
+cases, this is fine.
 
 > Your account was flagged by our Abuse team.
 
@@ -137,7 +139,8 @@ _One exception_ is when you want to specifically emphasize the action over the s
 
 Someone reading technical content is usually looking to answer a specific question.
 
-We don’t want to overload our audience with unnecessary information, choices, or complex ideas or phrases when we don’t have to.
+We don’t want to overload our audience with unnecessary information, choices, or complex ideas or
+phrases when we don’t have to.
 
 Guidelines:
 
@@ -157,7 +160,8 @@ Consider the following:
 - Could someone quickly scan this document and understand the material?
 - If someone can’t see the colours, images or video, is the message still clear?
 - Is the markup clean and structured?
-- Mobile devices with accessibility features are increasingly becoming core communication tools, does this work well on them?
+- Mobile devices with accessibility features are increasingly becoming core communication tools,
+  does this work well on them?
 
 ---
 

--- a/docs/learning/useful-resources/designing-and-running-experiment.md
+++ b/docs/learning/useful-resources/designing-and-running-experiment.md
@@ -177,8 +177,8 @@ Product assumptions have 2 main criteria: risk and difficulty. As an entrepreneu
 on the riskiest assumptions first but as a product owner (or you working in a squad with limited
 resources and skills) you should consider both factors.
 
-**Large companies’ mentality:** You are working on many things, so the design team and dev team
-have to ration their time to decide what the task in hand is going to be.
+**Large companies’ mentality:** You are working on many things, so the design team and dev team have
+to ration their time to decide what the task in hand is going to be.
 
 **Risks**: how risky the assumption is to potential feature or product as a whole. Remember some can
 sink the ship and some change its course.

--- a/docs/marketing/pitch.md
+++ b/docs/marketing/pitch.md
@@ -1,19 +1,29 @@
 # Thoth Tech Pitch Points
 
-Thoth Tech’s mission is to build, operate and deploy education technologies, creating tools that enhance education outcomes by empowering students, connecting them with tutors and facilitating personalised learning experiences.
+Thoth Tech’s mission is to build, operate and deploy education technologies, creating tools that
+enhance education outcomes by empowering students, connecting them with tutors and facilitating
+personalised learning experiences.
 
-We value our people and we value excellence: We are people-focused, aim to produce products of excellent quality, sustainability and to provide frameworks that provide a safe environment for learning and support of team-members
+We value our people and we value excellence: We are people-focused, aim to produce products of
+excellent quality, sustainability and to provide frameworks that provide a safe environment for
+learning and support of team-members
 
-- A chance to develop your technical skills and understanding across multiple disciplines which will make you a better version of whatever role is in your career roles
-- As well as applying crucial soft skills and understanding of how different roles within a company interact and collaborate
+- A chance to develop your technical skills and understanding across multiple disciplines which will
+  make you a better version of whatever role is in your career roles
+- As well as applying crucial soft skills and understanding of how different roles within a company
+  interact and collaborate
 - Focus on learning, support and mentoring
 
 ## Products
 
-- **Ontrack**: Ontrack is an education platform to connect tutors and students at Deakin university and is also used at other universities around the world.
-- **SplashKit**: SplashKit is a C++ Software Development Kit. It is a beginner's all-purpose software toolkit and can be used to create 2D games.
+- **Ontrack**: Ontrack is an education platform to connect tutors and students at Deakin university
+  and is also used at other universities around the world.
+- **SplashKit**: SplashKit is a C++ Software Development Kit. It is a beginner's all-purpose
+  software toolkit and can be used to create 2D games.
 
-The focus this trimester is on new feature design and development, existing feature upgrades, integrations, company planning, testing, data analysis and innovation, documentation and building a pipeline
+The focus this trimester is on new feature design and development, existing feature upgrades,
+integrations, company planning, testing, data analysis and innovation, documentation and building a
+pipeline
 
 ## Current Tech Stack
 
@@ -21,10 +31,15 @@ Ruby on Rails, Rabbit MQ, Docker, Angular, C/C++, TypeScript, Bootstrap, CoffeeS
 
 ## Recruiting
 
-We are looking for a large range of roles including Front-End Engineers, Back-End Engineers, Full-Stack Engineers, Data Scientists, Product Analysts, Quality Analysts, Business Analysts, Delivery Leads, Cloud Engineers, Architects, DevOps Engineers, Security Analysts, and a variety of leadership roles.
+We are looking for a large range of roles including Front-End Engineers, Back-End Engineers,
+Full-Stack Engineers, Data Scientists, Product Analysts, Quality Analysts, Business Analysts,
+Delivery Leads, Cloud Engineers, Architects, DevOps Engineers, Security Analysts, and a variety of
+leadership roles.
 
 ## My experience from Capstone
 
-Helped me build confidence, all type of skill development, leadership, project management, real world project exposure, really cool to develop and contribute to something we are all users of.
+Helped me build confidence, all type of skill development, leadership, project management, real
+world project exposure, really cool to develop and contribute to something we are all users of.
 
-We will be posting an ad in all channels later on today so feel free to message if you have any questions.
+We will be posting an ad in all channels later on today so feel free to message if you have any
+questions.

--- a/docs/marketing/recruitment-ad.md
+++ b/docs/marketing/recruitment-ad.md
@@ -1,18 +1,28 @@
 # Want to shape the future? Thoth Tech needs you!!
 
-Thoth Tech’s vision is to provide progressive, innovative and accessible education through our established products OnTrack and Splashkit. OnTrack is an education platform and SplashKit is an all purpose beginners kit that can be used to create 2D games. These products are already live and may have even helped you become the technologist you are today!
+Thoth Tech’s vision is to provide progressive, innovative and accessible education through our
+established products OnTrack and Splashkit. OnTrack is an education platform and SplashKit is an all
+purpose beginners kit that can be used to create 2D games. These products are already live and may
+have even helped you become the technologist you are today!
 
-Our current tech stack includes (but isn’t limited to) Ruby on Rails, Rabbit MQ, Docker, Angular, C/C++, Typescript, Bootstrap, Coffeescript, Python, Cpp.
+Our current tech stack includes (but isn’t limited to) Ruby on Rails, Rabbit MQ, Docker, Angular,
+C/C++, Typescript, Bootstrap, Coffeescript, Python, Cpp.
 
-If you are hungry to learn, want to gain valuable technical and soft skill experience, and are ready to get to work… then Thoth Tech is the company for you.
+If you are hungry to learn, want to gain valuable technical and soft skill experience, and are ready
+to get to work… then Thoth Tech is the company for you.
 
-Thoth Tech is recruiting for a large range of roles including Front-End Engineers, Back-End Engineers, Full-Stack Engineer, Data Scientists, Product Analysts, Quality Analysts, Business Analysts, Delivery Leads, Cloud Engineers, Architects, DevOps Engineers, Security Analysts, a variety of leadership roles + more.
+Thoth Tech is recruiting for a large range of roles including Front-End Engineers, Back-End
+Engineers, Full-Stack Engineer, Data Scientists, Product Analysts, Quality Analysts, Business
+Analysts, Delivery Leads, Cloud Engineers, Architects, DevOps Engineers, Security Analysts, a
+variety of leadership roles + more.
 
 ## Feeling overwhelmed and are not sure where you might fit in?
 
-Never fear, get in touch and our People Team can help you discover where your talents are most needed.
+Never fear, get in touch and our People Team can help you discover where your talents are most
+needed.
 
-If you have any questions, please don't hesitate to contact the Thoth Tech Leadership Team by email or MS Teams chat:
+If you have any questions, please don't hesitate to contact the Thoth Tech Leadership Team by email
+or MS Teams chat:
 
 - Managing Director (Staff Leader): Andrew Cain - andrew.cain@deakin.edu.au
 - Managing Director (Staff Leader) Glory Lee - glory.lee@deakin.edu.au

--- a/docs/peopleops/onboarding/onboarding-process.md
+++ b/docs/peopleops/onboarding/onboarding-process.md
@@ -2,16 +2,15 @@
 
 We are so excited you're here and look forward to setting you up for success.
 
-Onboarding is incredibly important at Thoth Tech. We don't expect you to hit the
-ground running from day one.
+Onboarding is incredibly important at Thoth Tech. We don't expect you to hit the ground running from
+day one.
 
-We highly recommend taking at least one full day for onboarding. Please feel
-free to participate in your team's work in the first two weeks, but don't feel
-like you are under heavy pressure. We are here to help.
+We highly recommend taking at least one full day for onboarding. Please feel free to participate in
+your team's work in the first two weeks, but don't feel like you are under heavy pressure. We are
+here to help.
 
-The onboarding process for the new team member is self-driven and self-learning,
-whilst also remaining as asynchronous as possible. It has been developed with
-three dimensions in mind, namely:
+The onboarding process for the new team member is self-driven and self-learning, whilst also
+remaining as asynchronous as possible. It has been developed with three dimensions in mind, namely:
 
 - Organisational Onboarding
 - Technical Onboarding
@@ -19,40 +18,47 @@ three dimensions in mind, namely:
 
 ## Accounts & Access
 
-- [ ] Submit the [onboarding form](https://teams.microsoft.com/l/entity/81fef3a6-72aa-4648-a763-de824aeafb7d/_djb2_msteams_prefix_1382414451?context=%7B%22subEntityId%22%3Anull%2C%22channelId%22%3A%2219%3AQfx_STHU90OsVYBHVYKhsRQ5gmEe0s9Q6kOpBf6bli81%40thread.tacv2%22%7D&groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6)
-- [ ] Set up a GitHub [account](https://docs.github.com/en/get-started/signing-up-for-github/signing-up-for-a-new-github-account) (if you do not have one already)
-- [ ] Add your contact details in this [doc](https://deakin365.sharepoint.com/:x:/r/sites/ThothTech2/Shared%20Documents/General/Administration/Personal%20Contacts.xlsx?d=w279b188c84544b269712dc4d2a6f7b87&csf=1&web=1).
-      You will receive an invite to the [Thoth Tech organisation](https://github.com/thoth-tech)
-      on GitHub within 24 hours. Being a member of the organisation allows
-      you to collaborate with others, create new repositories, manage
-      permissions and approval process more effectively.
-- [ ] Sign up for a [Miro](https://miro.com/contact/education/) account using
-      your Deakin email address. We use this tool for online collaboration.
-      The Leadership team will later create different projects and invite you.
+- [ ] Submit the
+      [onboarding form](https://teams.microsoft.com/l/entity/81fef3a6-72aa-4648-a763-de824aeafb7d/_djb2_msteams_prefix_1382414451?context=%7B%22subEntityId%22%3Anull%2C%22channelId%22%3A%2219%3AQfx_STHU90OsVYBHVYKhsRQ5gmEe0s9Q6kOpBf6bli81%40thread.tacv2%22%7D&groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6)
+- [ ] Set up a GitHub
+      [account](https://docs.github.com/en/get-started/signing-up-for-github/signing-up-for-a-new-github-account)
+      (if you do not have one already)
+- [ ] Add your contact details in this
+      [doc](https://deakin365.sharepoint.com/:x:/r/sites/ThothTech2/Shared%20Documents/General/Administration/Personal%20Contacts.xlsx?d=w279b188c84544b269712dc4d2a6f7b87&csf=1&web=1).
+      You will receive an invite to the [Thoth Tech organisation](https://github.com/thoth-tech) on
+      GitHub within 24 hours. Being a member of the organisation allows you to collaborate with
+      others, create new repositories, manage permissions and approval process more effectively.
+- [ ] Sign up for a [Miro](https://miro.com/contact/education/) account using your Deakin email
+      address. We use this tool for online collaboration. The Leadership team will later create
+      different projects and invite you.
 - [ ] Join the Trello board of your assigned projects.
 
 ## Company
 
-- [ ] The Thoth Tech charter helps to steer the ways we work and is a living document.
-      It is documented, refined and revised based on lessons learned in the course of doing business.
-      Please familiarise yourself with our [Charter](https://github.com/thoth-tech/handbook/blob/main/docs/company/charter.md).
+- [ ] The Thoth Tech charter helps to steer the ways we work and is a living document. It is
+      documented, refined and revised based on lessons learned in the course of doing business.
+      Please familiarise yourself with our
+      [Charter](https://github.com/thoth-tech/handbook/blob/main/docs/company/charter.md).
 
 ## Products
 
-We have three products at Thoth Tech: OnTrack, SplashKit and DreamBig. Depending
-on which team you are working with, you are expected to have a good level of
-understanding about the product and how to set it up. Please follow the
-applicable product onboarding below.
+We have three products at Thoth Tech: OnTrack, SplashKit and DreamBig. Depending on which team you
+are working with, you are expected to have a good level of understanding about the product and how
+to set it up. Please follow the applicable product onboarding below.
 
-- [ ] See [OnTrack onboarding](https://github.com/thoth-tech/handbook/blob/main/docs/products/ontrack/ontrack.md)
-- [ ] See [SplashKit onboarding](https://github.com/thoth-tech/handbook/blob/main/docs/products/splashkit.md)
-- [ ] See [DreamBig onboarding](https://github.com/thoth-tech/handbook/blob/main/docs/products/dreambig/dreambig.md)
+- [ ] See
+      [OnTrack onboarding](https://github.com/thoth-tech/handbook/blob/main/docs/products/ontrack/ontrack.md)
+- [ ] See
+      [SplashKit onboarding](https://github.com/thoth-tech/handbook/blob/main/docs/products/splashkit.md)
+- [ ] See
+      [DreamBig onboarding](https://github.com/thoth-tech/handbook/blob/main/docs/products/dreambig/dreambig.md)
 
 ## Social
 
-Starting in a new team can be overwhelming, how about schedule some calls with your team members. The Leadership
-team would also love to chat. There's no need to ask people if it's okay to schedule a call first. Schedule a
-meeting using Schedule Assistant in the Outlook calendar. Be sure to introduce yourself in the invite.
+Starting in a new team can be overwhelming, how about schedule some calls with your team members.
+The Leadership team would also love to chat. There's no need to ask people if it's okay to schedule
+a call first. Schedule a meeting using Schedule Assistant in the Outlook calendar. Be sure to
+introduce yourself in the invite.
 
 - [ ] Introduce yourself in the Social channel
 - [ ] Coffee chat with \_\_
@@ -63,9 +69,8 @@ meeting using Schedule Assistant in the Outlook calendar. Be sure to introduce y
 
 ### Delivery & Product Lead
 
-- [ ] Get to know your team. Have a look at your team members from the
-      onboarding manual document - this will give you a sense of the
-      roles we had in mind for them.
+- [ ] Get to know your team. Have a look at your team members from the onboarding manual document -
+      this will give you a sense of the roles we had in mind for them.
 - [ ] Book your first meeting.
 - [ ] Set up a project team channel on Microsoft Team.
 - [ ] Set up team work log to record activities of team members.
@@ -74,8 +79,9 @@ meeting using Schedule Assistant in the Outlook calendar. Be sure to introduce y
 - [ ] Decide on a team cadence - stand ups, retros, etc.
 - [ ] Decide on how meetings will run - meeting minutes, meeting agendas, etc.
 - [ ] How will you collaborate? - Miro? Trello Board?
-- [ ] Discuss what activities are needed - upskilling, scoping, etc. What do you need to plan your project?
-- [ ] Discuss area alignments for your team - the thing they want to drive (e.g.
-      Tech, QA, Docs, Data - ideally a balance).
+- [ ] Discuss what activities are needed - upskilling, scoping, etc. What do you need to plan your
+      project?
+- [ ] Discuss area alignments for your team - the thing they want to drive (e.g. Tech, QA, Docs,
+      Data - ideally a balance).
 - [ ] Information about QA Process to come to talk about in your team meetings.
 - [ ] Discussion around project tasks - ensuring everyone is aligned.

--- a/docs/processes/documentation/index.md
+++ b/docs/processes/documentation/index.md
@@ -1,16 +1,23 @@
 # Documentation
 
-Thoth Tech prides itself on our ability to produce sustainable solutions, this can be achieved through documentation.
-Documentation is an important element in the software development life cycle. It continues throughout the entire project.
-It is imperative to remember, others will take over your projects or want to learn more about how it works and why.
+Thoth Tech prides itself on our ability to produce sustainable solutions, this can be achieved
+through documentation. Documentation is an important element in the software development life cycle.
+It continues throughout the entire project. It is imperative to remember, others will take over your
+projects or want to learn more about how it works and why.
 
-Documentation is offical information, provided by the company, for users and contributors. Documentation is written for specific audiences and provides knowledge on the development lifecycle and end product.
+Documentation is offical information, provided by the company, for users and contributors.
+Documentation is written for specific audiences and provides knowledge on the development lifecycle
+and end product.
 
-The Thoth Tech documentation is stored in the [documentation repositry](https://github.com/thoth-tech/documentation)., in the company GitHub. All documentation should be written in markdown and includes: research, meeting minutes, software user guides, and more.
+The Thoth Tech documentation is stored in the
+[documentation repositry](https://github.com/thoth-tech/documentation)., in the company GitHub. All
+documentation should be written in markdown and includes: research, meeting minutes, software user
+guides, and more.
 
 ## Top tips for Thoth Tech writing
 
-Effective writing is clear, easy to read, and concise. Thoth Tech writing should follow the guidelines of plain English (Australian English).
+Effective writing is clear, easy to read, and concise. Thoth Tech writing should follow the
+guidelines of plain English (Australian English).
 
 Here at Thoth Tech, we aim for all our writing to meet these goals:
 
@@ -18,7 +25,8 @@ Here at Thoth Tech, we aim for all our writing to meet these goals:
 
 - **To Respect:** We want our people to feel included and accepted for who they are.
 
-- **To Educate:** We want to assist our people in their learning and provide them with the information they need.
+- **To Educate:** We want to assist our people in their learning and provide them with the
+  information they need.
 
 - **To Guide:** We want to lead our people in a thoughtful manner towards their goals.
 

--- a/docs/processes/documentation/writing-style-guide.md
+++ b/docs/processes/documentation/writing-style-guide.md
@@ -1,6 +1,7 @@
 # Writing Style Guide <!-- omit in toc -->
 
-The writing style guide is designed to inform decision when writing on behalf of Thoth Tech. This is a live guide and will ensure consistency across all Thoth Tech communications.
+The writing style guide is designed to inform decision when writing on behalf of Thoth Tech. This is
+a live guide and will ensure consistency across all Thoth Tech communications.
 
 While writing, it is important to:
 
@@ -45,7 +46,8 @@ While writing, it is important to:
 
 ### Headings
 
-Headings should be clear and concise. All content should relate to the heading or provide links to other information sources.
+Headings should be clear and concise. All content should relate to the heading or provide links to
+other information sources.
 
 Article headings should not be in a question format.
 
@@ -53,9 +55,11 @@ Use h1 (#) for article headings.
 
 ### Subheadings
 
-Subheadings are used to highlight a specific paragraph or area of content. All content should apply to this specific subheading.
+Subheadings are used to highlight a specific paragraph or area of content. All content should apply
+to this specific subheading.
 
-Avoid multi-tiered subheadings, use a maximum of three layers as a guide. If you need more than three layers, consider creating a separate article.
+Avoid multi-tiered subheadings, use a maximum of three layers as a guide. If you need more than
+three layers, consider creating a separate article.
 
 Subheadings can be in a question format where appropriate.
 
@@ -63,25 +67,30 @@ Use h2 (##) or h3 (###) for subheadings. Choice depends on the layer.
 
 ### Notes
 
-Information that is outside the scope of the content should be placed as a note if it necessary for the reader to understand.
+Information that is outside the scope of the content should be placed as a note if it necessary for
+the reader to understand.
 
-Content within a note should be separate from the main content, short, and to the point. A link to more information can be provided within the note section
+Content within a note should be separate from the main content, short, and to the point. A link to
+more information can be provided within the note section
 
 ### Hyperlinks
 
 Consider using hyperlinks (links) to ensure all information is relevant only to the article at hand.
 
-When an article references information that is out of scope, the reader can be linked to other information sources.
+When an article references information that is out of scope, the reader can be linked to other
+information sources.
 
 For example:
 
-> One reference for Australian spelling is the [Macquarie Dictionary](https://www.macquariedictionary.com.au/).
+> One reference for Australian spelling is the
+> [Macquarie Dictionary](https://www.macquariedictionary.com.au/).
 
 ### Lists
 
-The sentence leading into a list should end in a colon (:).
-If each item in the list is a full sentence, capitalise the first letter and end each item with a full stop.
-Otherwise, if the items are fragments of a sentence, each item should start in lowercase. Use a full stop at the end of the last item.
+The sentence leading into a list should end in a colon (:). If each item in the list is a full
+sentence, capitalise the first letter and end each item with a full stop. Otherwise, if the items
+are fragments of a sentence, each item should start in lowercase. Use a full stop at the end of the
+last item.
 
 #### Unordered/bullet list
 
@@ -98,7 +107,8 @@ To create unordered list items in markdown, use a dash (-).
 
 #### Ordered/numbered list
 
-An ordered list should be used when the order of the items is important, for example, step-by-step instructions.
+An ordered list should be used when the order of the items is important, for example, step-by-step
+instructions.
 
 Follow these steps to create an ordered list:
 
@@ -134,19 +144,23 @@ For complex numbers, use a combination
 
 ### Sentences
 
-The purpose of a sentence is to deliver a single message. The average sentence will have a length of 15-20 words Thoth Tech has a maximum length of 25 words.
+The purpose of a sentence is to deliver a single message. The average sentence will have a length of
+15-20 words Thoth Tech has a maximum length of 25 words.
 
 A variety of sentence lengths will engage your reader.
 
 Put qualifying phrases, conditions, and explanations into separate sentences.
 
-If you want to elaborate on the same point in a new sentence, use words like 'also', 'further', or 'however'.
+If you want to elaborate on the same point in a new sentence, use words like 'also', 'further', or
+'however'.
 
-If there are multiple points in a single sentence, consider using several shorter sentences, dot points, colons, or notes.
+If there are multiple points in a single sentence, consider using several shorter sentences, dot
+points, colons, or notes.
 
 Maintain order in paragraphs.
 
-If a sentence establishes an order, explain each item in the same order. This will help with flow and consistency.
+If a sentence establishes an order, explain each item in the same order. This will help with flow
+and consistency.
 
 Avoid repetition and redundancy.
 
@@ -222,7 +236,8 @@ For example:
 
 \*Avoid using contractions.
 
-End of sentence punctuation does not need to be included in titles, headings, subheadings, UI titles, and lists.
+End of sentence punctuation does not need to be included in titles, headings, subheadings, UI
+titles, and lists.
 
 ### Tone
 
@@ -246,7 +261,9 @@ For example:
 
 ### Technical content
 
-Technical content is the information about the underlying architecture, materials, and processes required to understand existing technology. Technical content typically requires some level of existing knowledge about the content.
+Technical content is the information about the underlying architecture, materials, and processes
+required to understand existing technology. Technical content typically requires some level of
+existing knowledge about the content.
 
 Technical content should include:
 
@@ -254,11 +271,16 @@ Technical content should include:
 - Revision date
 - Version ID
 
-When writing technical content, always consider the audience's skill. Assume the reader understands the fundamentals, but never more than that. If you are unsure, provide a link to more thorough information.
+When writing technical content, always consider the audience's skill. Assume the reader understands
+the fundamentals, but never more than that. If you are unsure, provide a link to more thorough
+information.
 
-Define technical terms in the context they are referred to and use frequently used words where possible.
+Define technical terms in the context they are referred to and use frequently used words where
+possible.
 
-If a term already exists, do not create a new word/phrase. Use these terms consistently throughout the article, and across Thoth Tech. Use industry specific terms when writing for a professional audience.
+If a term already exists, do not create a new word/phrase. Use these terms consistently throughout
+the article, and across Thoth Tech. Use industry specific terms when writing for a professional
+audience.
 
 ### Code examples
 
@@ -270,36 +292,45 @@ Code examples serve a range of scenarios:
 
 To create useful code examples, you should identify tasks and scenarios for your audience.
 
-Create concise examples of key development tasks, easy to read and understand. Show the expected output within the code example.
+Create concise examples of key development tasks, easy to read and understand. Show the expected
+output within the code example.
 
 Create sustainable and secure code examples. Follow best practice.
 
-Ensure the code is easy to replicate and run. If possible, provide an option to copy the code directly from the page.
+Ensure the code is easy to replicate and run. If possible, provide an option to copy the code
+directly from the page.
 
 ### Writing instructions/steps
 
-Instructions are used when a reader wants to learn. Therefore, the steps must be clear, easy to understand, and follow.
+Instructions are used when a reader wants to learn. Therefore, the steps must be clear, easy to
+understand, and follow.
 
-Emphasis should be placed on the main direction. Use **bold** to highlight key words or phrases which indicate the action or outcome.
+Emphasis should be placed on the main direction. Use **bold** to highlight key words or phrases
+which indicate the action or outcome.
 
-Make sure the reader knows where the action should take place before you describe the action. If necessary, provide an introductory step to highlight the area.
+Make sure the reader knows where the action should take place before you describe the action. If
+necessary, provide an introductory step to highlight the area.
 
-Throughout step-by-step instructions, formatting and language must be consistent. Capitalise the first word of full sentences, and full stop at the end.
+Throughout step-by-step instructions, formatting and language must be consistent. Capitalise the
+first word of full sentences, and full stop at the end.
 
-A separate numbered entry should be used for each step. Each step should be a complete sentence in imperative verb form, including actions that finalise the step.
+A separate numbered entry should be used for each step. Each step should be a complete sentence in
+imperative verb form, including actions that finalise the step.
 
 Limit the number of steps to seven, and fit all steps onto the same screen.
 
 For single-step procedures, follow the same format, but use an unordered list instead of ordered.
 
-When writing simple sequences, you can use `A > B > C` format. However, this should be used sparingly due to accessibility tool limitations.
+When writing simple sequences, you can use `A > B > C` format. However, this should be used
+sparingly due to accessibility tool limitations.
 
 For example:
 
 > **To increase text size of a note:**
 >
 > 1. On the Whiteboard, select the notes you want to increase the size.
-> 2. From the toolbox, select the A+ icon until you reach the desired size. Click anywhere in the Whiteboard to deselect.
+> 2. From the toolbox, select the A+ icon until you reach the desired size. Click anywhere in the
+>    Whiteboard to deselect.
 >
 > **To move a note:**
 >
@@ -307,9 +338,11 @@ For example:
 
 ## Bias-free communication
 
-When creating documentation, we have an obligation to respect all individuals. At Thoth Tech we promote an inclusive and supportive environment. This extends to our communication.
+When creating documentation, we have an obligation to respect all individuals. At Thoth Tech we
+promote an inclusive and supportive environment. This extends to our communication.
 
-We have a responsibility to respect diversity and promote inclusion through all our communication. As such we enforce the following guidelines for bias-free communication.
+We have a responsibility to respect diversity and promote inclusion through all our communication.
+As such we enforce the following guidelines for bias-free communication.
 
 Use gender-neutral alternatives.
 
@@ -329,15 +362,20 @@ Exceptions include:
 
 - if you are referring to a real person. Please use their preferred pronouns in this case.
 - direct quotations and titles of works
-- when gender is relevant. For example, diversity challenges. <!-- Would prefer a different example-->
+- when gender is relevant. For example, diversity challenges.
+  <!-- Would prefer a different example-->
 
-When referring to accessibility challenges focus on people, not disabilities. For example: readers who have low vision or blind
+When referring to accessibility challenges focus on people, not disabilities. For example: readers
+who have low vision or blind
 
-When creating fictitious scenarios, include a diverse range of names and roles. Do not elude to stereotypes or generalisations and do not primarily write of Western ideals.
+When creating fictitious scenarios, include a diverse range of names and roles. Do not elude to
+stereotypes or generalisations and do not primarily write of Western ideals.
 
-When including country names, be conscious of political disputes and do not mix countries states or continents.
+When including country names, be conscious of political disputes and do not mix countries states or
+continents.
 
-Do not use slang or jargon as it can be confusing or offensive for the reader. Similarly, do not use loaded terms.
+Do not use slang or jargon as it can be confusing or offensive for the reader. Similarly, do not use
+loaded terms.
 
 | Loaded term        | Substitute             |
 | ------------------ | ---------------------- |
@@ -352,15 +390,20 @@ Do not use profane/derogatory terms.
 
 ## Global communication
 
-Thoth Tech is an open-source company with a potentially global reach. We value education and creating learning opportunities.
+Thoth Tech is an open-source company with a potentially global reach. We value education and
+creating learning opportunities.
 
-We have a responsibility to write and communicate in a way that is accessible via a translator, this is a part of our global citizenship. As such we enforce the following guidelines for global communication.
+We have a responsibility to write and communicate in a way that is accessible via a translator, this
+is a part of our global citizenship. As such we enforce the following guidelines for global
+communication.
 
-Keep your writing short and simple, break a complex sentence into multiple simple sentences. Avoid linking more than three phrases.
+Keep your writing short and simple, break a complex sentence into multiple simple sentences. Avoid
+linking more than three phrases.
 
 Use lists and tables to reduce complexity.
 
-Include 'that', 'who', and 'the'. These can provide clarity in the sentence structure for the reader or translator.
+Include 'that', 'who', and 'the'. These can provide clarity in the sentence structure for the reader
+or translator.
 
 Particularly for machine translation:
 

--- a/docs/processes/quality-assurance/git-contribution-guide.md
+++ b/docs/processes/quality-assurance/git-contribution-guide.md
@@ -14,37 +14,50 @@
 
 ## Contributing to Repositories: How To
 
-Repositories are where existing Thoth Tech code is stored, and where new code contributions, once tested and approved, will ultimately be merged.
+Repositories are where existing Thoth Tech code is stored, and where new code contributions, once
+tested and approved, will ultimately be merged.
 
-In order to begin new work on your project, you will need to clone a local copy of the relevant Thoth Tech repository.
+In order to begin new work on your project, you will need to clone a local copy of the relevant
+Thoth Tech repository.
 
 Steps:
 
 _If you have never worked on the repository before:_
 
-- Clone your project's relevant Thoth Tech repository to your local machine and navigate to the created project folder; you will find yourself on the default branch (main/master).
+- Clone your project's relevant Thoth Tech repository to your local machine and navigate to the
+  created project folder; you will find yourself on the default branch (main/master).
 
 _If you already have a copy of this repository on your local machine_
 
-- From the main/master branch of your local copy of the repository, make sure to do a git "pull" to make sure you are working on the latest copy of code from the origin (this will include any changes merged to the main branch since you last cloned/pulled the repo).
+- From the main/master branch of your local copy of the repository, make sure to do a git "pull" to
+  make sure you are working on the latest copy of code from the origin (this will include any
+  changes merged to the main branch since you last cloned/pulled the repo).
 
 _Then:_
 
 - Create a new branch (as per [Branching Guide](#branching-guidelines)) for your changes
 - Make your code changes on the branch you created
-- When complete, commit your changes, using the format provided in the [commit guidelines](#commit-guidelines).
+- When complete, commit your changes, using the format provided in the
+  [commit guidelines](#commit-guidelines).
 - Push the branch to origin
-- Create a [draft Pull Request](#draft-pull-request) (PR) for merging the branch into the main Thoth Tech branch for your repository, adding [required approvals](#required-approvals) (note: it will be blocked from merging while in draft form). Comment on the progress and any feedback sought.
-- Continue making changes on your local branch, committing and pushing your changes, until you are satisfied the code is complete, passing all tests and relevant acceptance criteria, and ready for merging
+- Create a [draft Pull Request](#draft-pull-request) (PR) for merging the branch into the main Thoth
+  Tech branch for your repository, adding [required approvals](#required-approvals) (note: it will
+  be blocked from merging while in draft form). Comment on the progress and any feedback sought.
+- Continue making changes on your local branch, committing and pushing your changes, until you are
+  satisfied the code is complete, passing all tests and relevant acceptance criteria, and ready for
+  merging
 - Publish your Pull request by changing the status to ready for review
 
-An example sequence of git commands used in this process is provided in the [Git Workflow Summary](#git-workflow-summary).
+An example sequence of git commands used in this process is provided in the
+[Git Workflow Summary](#git-workflow-summary).
 
 ## Branching Guidelines
 
-No commits should be made directly to the default branch (usually main/master/develop). Instead, branches should be created off the default branch to encompass any changes.
+No commits should be made directly to the default branch (usually main/master/develop). Instead,
+branches should be created off the default branch to encompass any changes.
 
-Branches must have descriptive names, including a reference the task/subtask number the work relates to, using the following format:
+Branches must have descriptive names, including a reference the task/subtask number the work relates
+to, using the following format:
 
 | Branch naming format                                   | Use                                            |
 | ------------------------------------------------------ | ---------------------------------------------- |
@@ -52,7 +65,8 @@ Branches must have descriptive names, including a reference the task/subtask num
 | `fix/<project_task or subtask number_description>`     | For a fix                                      |
 | `doc/<project_task or subtask number_description>`     | Non-feature-related document additions/changes |
 
-For an example, let's assume the following hypothetical task breakdown for the Voice Verification project (we might expect these numbers to be reflected in a Trello task cards):
+For an example, let's assume the following hypothetical task breakdown for the Voice Verification
+project (we might expect these numbers to be reflected in a Trello task cards):
 
 Product/Epic:
 
@@ -71,7 +85,8 @@ _Tasks:_
 
    3.1 _\<subtask\>_
 
-A programmer who is going to commence work on the Voice Verification component subtask 1.2 should use a branch named: _feature/voice-verification-1.2-store-voice-input_
+A programmer who is going to commence work on the Voice Verification component subtask 1.2 should
+use a branch named: _feature/voice-verification-1.2-store-voice-input_
 
 This would be created and checked out by using the git command:
 
@@ -81,7 +96,11 @@ git checkout -b feature/voice-verification-1.2-store-voice-input
 
 ## Commit Guidelines
 
-Thoth Tech follows the same Git commit message format as required by the Doubtfire LMS (source doubtfire-lms's [CONTRIBUTING.md](https://github.com/doubtfire-lms/doubtfire-deploy/blob/development/CONTRIBUTING.md#commit-message-format)) which this section predominantly mirrors. This format makes for an easier to read and more useful commit history.
+Thoth Tech follows the same Git commit message format as required by the Doubtfire LMS (source
+doubtfire-lms's
+[CONTRIBUTING.md](https://github.com/doubtfire-lms/doubtfire-deploy/blob/development/CONTRIBUTING.md#commit-message-format))
+which this section predominantly mirrors. This format makes for an easier to read and more useful
+commit history.
 
 ### Message Format
 
@@ -97,9 +116,11 @@ Each commit message consists of a header, a body, and a footer.
 
 The **header** is mandatory and must conform to the Commit Message Header format.
 
-The **body** is recommended for all commits. When the body is present, it must be at least 20 characters long and conform to the Commit Message Body format.
+The **body** is recommended for all commits. When the body is present, it must be at least 20
+characters long and conform to the Commit Message Body format.
 
-The **footer** is optional. The Commit Message Footer format describes the purpose and structure of the footer.
+The **footer** is optional. The Commit Message Footer format describes the purpose and structure of
+the footer.
 
 Any line of the commit message should be 100 characters or fewer.
 
@@ -119,8 +140,10 @@ The `<type>` and `<summary>` fields are mandatory, the (`<scope>`) field is opti
 
 The `<type>` must be one of the following:
 
-- **build** : Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-- **ci** : Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
+- **build** : Changes that affect the build system or external dependencies (example scopes: gulp,
+  broccoli, npm)
+- **ci** : Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack,
+  SauceLabs)
 - **docs** : Documentation only changes
 - **feat** : A new feature
 - **fix** : A bug fix
@@ -128,7 +151,9 @@ The `<type>` must be one of the following:
 - **refactor** : A code change that neither fixes a bug nor adds a feature
 - **test** : Adding missing tests or correcting existing tests
 
-Doubtfire-LMS recommends Chris Beam's post on [How to Write Good Commit Messages](http://chris.beams.io/posts/git-commit/) to improve your commit message writing.
+Doubtfire-LMS recommends Chris Beam's post on
+[How to Write Good Commit Messages](http://chris.beams.io/posts/git-commit/) to improve your commit
+message writing.
 
 **Use the imperative mood in your commit subject line**
 
@@ -140,13 +165,16 @@ Write your commits in the imperative mood and not the indicative mood
 
 Keep the subject line (top line) concise; keep it **within 50 characters**.
 
-Use the body (lines after the top line) to explain why and what and _not_ how; keep it **within 72 characters**.
+Use the body (lines after the top line) to explain why and what and _not_ how; keep it **within 72
+characters**.
 
 ### But how can I write new lines if I'm using `git commit -m "Message"`?
 
 Don't use the `-m` switch. Use a text editor to write your commit message instead.
 
-If you are using the command line to write your commits, it is useful to set your git editor to make writing a commit body easier. You can use the following command to set your editor to Visual Studio Code, `nano`, `emacs`, `vim`, `atom`.
+If you are using the command line to write your commits, it is useful to set your git editor to make
+writing a commit body easier. You can use the following command to set your editor to Visual Studio
+Code, `nano`, `emacs`, `vim`, `atom`.
 
 ```shell
 git config --global core.editor "code --wait"
@@ -158,37 +186,46 @@ git config --global core.editor "atom --wait"
 
 ## Code Review Guidelines
 
-You are strongly encouraged to get your code reviewed by a reviewer as soon as
-there is any code to review, to get a second opinion on the chosen solution and
-implementation, and an extra pair of eyes looking for bugs, logic problems, or
-uncovered edge cases.
+You are strongly encouraged to get your code reviewed by a reviewer as soon as there is any code to
+review, to get a second opinion on the chosen solution and implementation, and an extra pair of eyes
+looking for bugs, logic problems, or uncovered edge cases.
 
 ### Draft Pull Request
 
-Draft Pull Requests allow a work in progress to receive early feedback. The developer creating the PR should, in the description, indicate their progress and any particular aspect they are looking for feedback on. When the PR is ready for final review, the developer should update the description, re-request reviews as required and change the status to "ready to review".
+Draft Pull Requests allow a work in progress to receive early feedback. The developer creating the
+PR should, in the description, indicate their progress and any particular aspect they are looking
+for feedback on. When the PR is ready for final review, the developer should update the description,
+re-request reviews as required and change the status to "ready to review".
 
-Pull requests (draft and otherwise) are created from the GitHub website. Further information about draft pull requests, how to make them, and how to convert their status to ready for merging can be found on GitHub's [Introducing Draft Pull Requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) blog.
+Pull requests (draft and otherwise) are created from the GitHub website. Further information about
+draft pull requests, how to make them, and how to convert their status to ready for merging can be
+found on GitHub's
+[Introducing Draft Pull Requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/)
+blog.
 
 ### Required Approvals
 
-Pull requests require **a minimum of two approvals**. The default approach is to
-choose a reviewer from your team for the first review. However, the reviewer may
-be from different team, for example a domain expert in a programming language,
-quality assurance process, telemetry or documentation. Depending on the team
-size and dynamics, the number of required approvals can be higher or lower.
-Think about the tradeoffs between velocity with quality when deciding on an
-approval process for your team.
+Pull requests require **a minimum of two approvals**. The default approach is to choose a reviewer
+from your team for the first review. However, the reviewer may be from different team, for example a
+domain expert in a programming language, quality assurance process, telemetry or documentation.
+Depending on the team size and dynamics, the number of required approvals can be higher or lower.
+Think about the tradeoffs between velocity with quality when deciding on an approval process for
+your team.
 
-The required approvals rules can be set via the [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule).
-All the leads should have access to change these settings and should ensure this
-is configured when creating a new GitHub repository. For more information on how
-to set this up correctly, see this [guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/useful-resources/setup-new-github-repository.md).
+The required approvals rules can be set via the
+[branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule).
+All the leads should have access to change these settings and should ensure this is configured when
+creating a new GitHub repository. For more information on how to set this up correctly, see this
+[guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/useful-resources/setup-new-github-repository.md).
 
 ## Git Workflow Summary
 
 ### Start a new piece of work
 
-1. Synch repo and set up for your new feature branch (remember to use Thoth Tech [branching guidelines](#branching-guidelines) for naming the new branch; we have used the guideline example of _feature/voice-verification-1.2-store-voice-input_ for our workflow illustration):
+1. Synch repo and set up for your new feature branch (remember to use Thoth Tech
+   [branching guidelines](#branching-guidelines) for naming the new branch; we have used the
+   guideline example of _feature/voice-verification-1.2-store-voice-input_ for our workflow
+   illustration):
 
    ```shell
    git checkout main
@@ -196,7 +233,8 @@ to set this up correctly, see this [guide](https://github.com/thoth-tech/handboo
    git checkout -b feature/voice-verification-1.2-store-voice-input
    ```
 
-2. Make changes, commit (using comments format that follows [commit guidelines](#commit-guidelines)) and push to origin:
+2. Make changes, commit (using comments format that follows [commit guidelines](#commit-guidelines))
+   and push to origin:
 
    ```shell
    git add .
@@ -204,7 +242,8 @@ to set this up correctly, see this [guide](https://github.com/thoth-tech/handboo
    git push -u origin feature/voice-verification-1.2-store-voice-input
    ```
 
-3. Remember to submit a [draft pull request](#draft-pull-request) via GitHub to allow for code review (and mark as ready to submit when ready to merge your changes to main).
+3. Remember to submit a [draft pull request](#draft-pull-request) via GitHub to allow for code
+   review (and mark as ready to submit when ready to merge your changes to main).
 
 ### Continue a piece of work
 
@@ -226,7 +265,10 @@ to set this up correctly, see this [guide](https://github.com/thoth-tech/handboo
 
 ### Collaborate on an existing branch
 
-Ideally, we should avoid having developers working on the same code. It creates merge conflicts and hinders efficiency. If possible, try to break it down into small tasks so developers can work independently. In the worst-case scenario, if there is more than 1 person working on a feature branch:
+Ideally, we should avoid having developers working on the same code. It creates merge conflicts and
+hinders efficiency. If possible, try to break it down into small tasks so developers can work
+independently. In the worst-case scenario, if there is more than 1 person working on a feature
+branch:
 
 1. Please make sure you pull changes in the remote branch before starting your work.
 
@@ -237,4 +279,5 @@ Ideally, we should avoid having developers working on the same code. It creates 
 2. Resolve any merge conflicts that may now be revealed.
 3. Continue to Step 2 in [Start a new piece of work](#start-a-new-piece-of-work) flow
 
-**Please avoid force-push and rebase when working on a shared branch**. It can cause complex and hard to resolve merge conflicts as well as undo others' commits accidentally.
+**Please avoid force-push and rebase when working on a shared branch**. It can cause complex and
+hard to resolve merge conflicts as well as undo others' commits accidentally.

--- a/docs/processes/quality-assurance/quality-assurance-overview.md
+++ b/docs/processes/quality-assurance/quality-assurance-overview.md
@@ -8,11 +8,18 @@
 
 ## Why/What is Quality Assurance?
 
-Quality Assurance (QA) is defined as a procedure to ensure the quality of software products or services provided to the customers by an organisation. Quality assurance focuses on improving the software development process and making it efficient and effective as per the quality standards defined for software products.
+Quality Assurance (QA) is defined as a procedure to ensure the quality of software products or
+services provided to the customers by an organisation. Quality assurance focuses on improving the
+software development process and making it efficient and effective as per the quality standards
+defined for software products.
 
 ## Software Development and Testing
 
-The [Testing and Development processes document](testing-and-dev.md) contains information and resources relating to the software conception and development process and documentation. It also explains the test driven development (TDD) process and contains information relating to feature development using this approach. As it makes testing part of the approach, it is best to be familiar with this document before you start coding.
+The [Testing and Development processes document](testing-and-dev.md) contains information and
+resources relating to the software conception and development process and documentation. It also
+explains the test driven development (TDD) process and contains information relating to feature
+development using this approach. As it makes testing part of the approach, it is best to be familiar
+with this document before you start coding.
 
 It covers key areas including:
 
@@ -31,7 +38,8 @@ It covers key areas including:
 
 ## Git Contribution Guide
 
-The [Git Contributions Guide](git-contribution-guide.md) concerns processes relating to the git workflow, branching and commit formatting guidelines and draft pull requests.
+The [Git Contributions Guide](git-contribution-guide.md) concerns processes relating to the git
+workflow, branching and commit formatting guidelines and draft pull requests.
 
 Key areas are:
 

--- a/docs/processes/quality-assurance/templates/bug-report-template.md
+++ b/docs/processes/quality-assurance/templates/bug-report-template.md
@@ -24,4 +24,6 @@ Include something to show the bug in action.
 
 Include any logs that show the error.
 
-_Based on template from_ [_Programming Foundations: Software Testing/QA_](https://www.linkedin.com/learning/programming-foundations-software-testing-qa/create-a-test-strategy?autoSkip=true&autoplay=true&contextUrn=urn%3Ali%3AlyndaLearningPath%3A57f7e27c3dd559e018dfe994&resume=false&u=2104084) _with Meaghan Lewis on LinkedIn Learning_
+_Based on template from_
+[_Programming Foundations: Software Testing/QA_](https://www.linkedin.com/learning/programming-foundations-software-testing-qa/create-a-test-strategy?autoSkip=true&autoplay=true&contextUrn=urn%3Ali%3AlyndaLearningPath%3A57f7e27c3dd559e018dfe994&resume=false&u=2104084)
+_with Meaghan Lewis on LinkedIn Learning_

--- a/docs/processes/quality-assurance/templates/pr-template.md
+++ b/docs/processes/quality-assurance/templates/pr-template.md
@@ -2,7 +2,8 @@ _Any italic text should be deleted from the final Pull Request text, including t
 
 # Description
 
-_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._
+_Please include a summary of the change and which issue is fixed. Please also include relevant
+motivation and context. List any dependencies that are required for this change._
 
 Fixes # (issue)
 
@@ -12,12 +13,14 @@ _Please delete options that are not relevant._
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
+      expected)
 - [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
-_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_
+_Please describe the tests that you ran to verify your changes. Provide instructions so we can
+reproduce. Please also list any relevant details for your test configuration_
 
 ## Testing Checklist:
 

--- a/docs/processes/quality-assurance/templates/test-strategy-template.md
+++ b/docs/processes/quality-assurance/templates/test-strategy-template.md
@@ -6,7 +6,9 @@ A high-level summary of the project
 
 ### **Example**
 
-This strategy outlines what quality provides to the project, what type of testing is done, and how testing is carried out. The aim is to ensure quality in all phases of the development lifecycle to deliver a great experience for our users.
+This strategy outlines what quality provides to the project, what type of testing is done, and how
+testing is carried out. The aim is to ensure quality in all phases of the development lifecycle to
+deliver a great experience for our users.
 
 ## **References**
 
@@ -15,9 +17,11 @@ Relevant links and helpful information about the project and its tech stack
 ### **Examples**
 
 - GitHubproject: \<github link\>
-- Jasmine is used as a unit testing framework [https://jasmine.github.io/](https://jasmine.github.io/)
+- Jasmine is used as a unit testing framework
+  [https://jasmine.github.io/](https://jasmine.github.io/)
 - Cypress is used for end-to-end testing [https://www.cypress.io/](https://www.cypress.io/)
-- Karma is used for testing automation [https://karma-runner.github.io/latest/index.html](https://karma-runner.github.io/latest/index.html)
+- Karma is used for testing automation
+  [https://karma-runner.github.io/latest/index.html](https://karma-runner.github.io/latest/index.html)
 - App is built using Node.js: [http://nodejs.org/](http://nodejs.org/)
 
 ## **QA Deliverables**
@@ -32,13 +36,15 @@ What artifacts QA will provide to the team (eg, Test Strategy, Sample Test Plan,
 
 ## **Test Management**
 
-What resources are used to carry out testing in terms of tooling, environments, supported platforms and versions, and test data
+What resources are used to carry out testing in terms of tooling, environments, supported platforms
+and versions, and test data
 
 ### **Examples**
 
 - Jenkins is used to build test versions of the application off of master and PRs
 - VMs are used to test the applications in Windows
-- Test runs are input in Testpad to make it clear what scenarios were tested and if those scenarios pass or fail
+- Test runs are input in Testpad to make it clear what scenarios were tested and if those scenarios
+  pass or fail
 - Supported operating systems are Windows 7 and 10 and Mac
 - Test data will include user accounts
 
@@ -52,4 +58,6 @@ What types of tests exist for this project?
 - Written during development—by developers
 - Automated UI tests for high-level workflows
 
-_Based on template from_ [_Programming Foundations: Software Testing/QA_](https://www.linkedin.com/learning/programming-foundations-software-testing-qa/create-a-test-strategy?autoSkip=true&autoplay=true&contextUrn=urn%3Ali%3AlyndaLearningPath%3A57f7e27c3dd559e018dfe994&resume=false&u=2104084) _with Meaghan Lewis on LinkedIn Learning_
+_Based on template from_
+[_Programming Foundations: Software Testing/QA_](https://www.linkedin.com/learning/programming-foundations-software-testing-qa/create-a-test-strategy?autoSkip=true&autoplay=true&contextUrn=urn%3Ali%3AlyndaLearningPath%3A57f7e27c3dd559e018dfe994&resume=false&u=2104084)
+_with Meaghan Lewis on LinkedIn Learning_

--- a/docs/processes/quality-assurance/testing-and-dev.md
+++ b/docs/processes/quality-assurance/testing-and-dev.md
@@ -16,7 +16,8 @@
   - [Refactoring Code](#refactoring-code)
 - [Testing Templates](#testing-templates)
 
-You might be wondering, before jumping into coding and planning tests for a new feature, _where do you begin_?
+You might be wondering, before jumping into coding and planning tests for a new feature, _where do
+you begin_?
 
 ## Feature development: where do I start?
 
@@ -30,16 +31,24 @@ You might be wondering, before jumping into coding and planning tests for a new 
   - What are the metrics for success?
   - What's in/out of scope?
 
-- Your extracted purpose and requirements will be documented within your [Software Requirements Specification](#software-requirements-specification-document) document.
+- Your extracted purpose and requirements will be documented within your
+  [Software Requirements Specification](#software-requirements-specification-document) document.
 - Plan your testing by defining your Test Strategy and Test Plan:
-  - Using your specifications, fleshout the expected behaviour for different use case scenarios; these will provide scenarios to be tested in your [Test Plan](#making-a-test-plan).
-  - Determine _how_ you are going to test your scenarios and describe this in your [Test Strategy](#test-strategy).
+  - Using your specifications, fleshout the expected behaviour for different use case scenarios;
+    these will provide scenarios to be tested in your [Test Plan](#making-a-test-plan).
+  - Determine _how_ you are going to test your scenarios and describe this in your
+    [Test Strategy](#test-strategy).
 
 ## Epics and User Stories
 
 ### Epics
 
-Epics describe a large body of work that will be broken down into smaller tasks (called user stories). Epics are a higher-level view of user request or needs that help with considering larger aims, what value the work described will bring to the business, organizing work and creating a hierarchy. Epics will be broken down into smaller, more manageable tasks ("user stories") to be completed by team members. A Markdown [Epic Template](../../leadership/epic-template.md) is also available.
+Epics describe a large body of work that will be broken down into smaller tasks (called user
+stories). Epics are a higher-level view of user request or needs that help with considering larger
+aims, what value the work described will bring to the business, organizing work and creating a
+hierarchy. Epics will be broken down into smaller, more manageable tasks ("user stories") to be
+completed by team members. A Markdown [Epic Template](../../leadership/epic-template.md) is also
+available.
 
 ### User Stories
 
@@ -49,35 +58,52 @@ User Stories are user-centric statements often put in the form of:
 
 This describes a _persona + need + purpose_.
 
-A **[persona]** – describes the person we are building this for. The persona is not just a role or job title; we want to have an understanding of who the person is, how they work, think and feel.
+A **[persona]** – describes the person we are building this for. The persona is not just a role or
+job title; we want to have an understanding of who the person is, how they work, think and feel.
 
-**[wants to]** – describes the user's _intent_ (what they want to achieve) and not the feature they use. If you are describing implementation specifics here, you are taking the wrong approach.
+**[wants to]** – describes the user's _intent_ (what they want to achieve) and not the feature they
+use. If you are describing implementation specifics here, you are taking the wrong approach.
 
-**[so that]** – explains the motivation behind the user's desire and the overall benefit to them from what they are trying to achieve.
+**[so that]** – explains the motivation behind the user's desire and the overall benefit to them
+from what they are trying to achieve.
 
-User stories use non-technical language to provide context and an understanding of what is to be built and why. They provide a framework for approaching development which is user-focused, discrete and small enough to be manageably tackled by team members in an Agile environment.
+User stories use non-technical language to provide context and an understanding of what is to be
+built and why. They provide a framework for approaching development which is user-focused, discrete
+and small enough to be manageably tackled by team members in an Agile environment.
 
 Benefits include:
 
-- Keeps focus on the user: keeps the team focused on solving real-world problems in user-centric ways.
-- Enables collaboration: by defining the end goal, the team can work together on deciding on how best to meet it
-- Drives creative solutions: the focus on the end-user solution required, rather than the how, encourages creative problem-solving (where to-do lists do not).
+- Keeps focus on the user: keeps the team focused on solving real-world problems in user-centric
+  ways.
+- Enables collaboration: by defining the end goal, the team can work together on deciding on how
+  best to meet it
+- Drives creative solutions: the focus on the end-user solution required, rather than the how,
+  encourages creative problem-solving (where to-do lists do not).
 
-In Agile methodology, during a sprint or iteration, the team decides which user stories to tackle that story and discuss requirements; once agreed, requirements are added to the stories; Story tasks and subtasks can be tracked and assigned using the team's relevant Trello board; user stories for future sprints can remain in the backlog.
+In Agile methodology, during a sprint or iteration, the team decides which user stories to tackle
+that story and discuss requirements; once agreed, requirements are added to the stories; Story tasks
+and subtasks can be tracked and assigned using the team's relevant Trello board; user stories for
+future sprints can remain in the backlog.
 
 When defining user stories, consider:
 
 - Definition of "done": how will we know when a task/story is complete?
 - Tasks or subtasks: what steps need to be completed and by whom?
-- User personas: who is the user being considered; are there multiple users (consider making user stories for each of them)
+- User personas: who is the user being considered; are there multiple users (consider making user
+  stories for each of them)
 - Ordered steps: In a larger process, write a story for _each step_
-- Time: consider how long a story may take; if it's more than one sprint, or seems very complex, the story may need to be broken down into smaller stories (or, you may be looking at an epic)
+- Time: consider how long a story may take; if it's more than one sprint, or seems very complex, the
+  story may need to be broken down into smaller stories (or, you may be looking at an epic)
 
-Further background on user stories can be found at https://www.atlassian.com/agile/project-management/user-stories
+Further background on user stories can be found at
+https://www.atlassian.com/agile/project-management/user-stories
 
 ## Software Requirements Specification Document
 
-A Software Requirements Specification (SRS) document describes the expectations for your product, how it should perform, and the functionality required to meet stakeholder needs. An [SRS template](templates/srs-template.md) has been provided which sets out an example format of an SRS, including the following components.
+A Software Requirements Specification (SRS) document describes the expectations for your product,
+how it should perform, and the functionality required to meet stakeholder needs. An
+[SRS template](templates/srs-template.md) has been provided which sets out an example format of an
+SRS, including the following components.
 
 - **Introduction**:
 
@@ -95,7 +121,8 @@ A Software Requirements Specification (SRS) document describes the expectations 
 
   - **Scope**
 
-    What are the goals and objectives for this product? What should the product do (And what should it _not_ do?)
+    What are the goals and objectives for this product? What should the product do (And what should
+    it _not_ do?)
 
   - **Definition and acronyms**
 
@@ -103,59 +130,96 @@ A Software Requirements Specification (SRS) document describes the expectations 
 
 - **Overall Description**
 
-  Describes your product and what you are going to build; describe here whether it is a new product, or an enhancement/add-on to an existing product, who it is for and why it has value. This explains the general background and factors affecting requirements (rather than the specific requirements themselves)
+  Describes your product and what you are going to build; describe here whether it is a new product,
+  or an enhancement/add-on to an existing product, who it is for and why it has value. This explains
+  the general background and factors affecting requirements (rather than the specific requirements
+  themselves)
 
   - **User Needs**
 
-    Who will use your product feature and how? What needs do your end users have that you need to be aware of?
+    Who will use your product feature and how? What needs do your end users have that you need to be
+    aware of?
 
   - **Assumptions and dependencies**
 
-    Provide any assumptions made (what are we assuming to be true) or dependencies for your product/feature
+    Provide any assumptions made (what are we assuming to be true) or dependencies for your
+    product/feature
 
 - **System Features and Requirements**
 
   - **Functional Requirements**
 
-    Fundamental requirements are essential requirements that, as the name suggests, provide functionality and are often described by "The system shall..." statements.
+    Fundamental requirements are essential requirements that, as the name suggests, provide
+    functionality and are often described by "The system shall..." statements.
 
   - **External Interface Requirements**
 
-    Specific requirements detailing hor your product interfaces with other components. They may include user, hardware, software and communications interfaces.
+    Specific requirements detailing hor your product interfaces with other components. They may
+    include user, hardware, software and communications interfaces.
 
   - **System Features**
 
-    _System features are types of functional requirements. These are features that are required in order for a system to function_
+    _System features are types of functional requirements. These are features that are required in
+    order for a system to function_
 
   - **Nonfunctional requirements**
 
-    Nonfunctional requirements are those relating to non-functional measures and relate to aspects such as performance, safety, security and quality.
+    Nonfunctional requirements are those relating to non-functional measures and relate to aspects
+    such as performance, safety, security and quality.
 
-Further references include Perforce's [How to Write an SRS Document](https://www.perforce.com/blog/alm/how-write-software-requirements-specification-srs-document) and, for a higher level of detail on recommended guidelines for the SRS elements, [IEEE’s Recommended Practice for Software Requirements Specifications](https://drive.google.com/file/d/1G1vQq-RjnbEmTTzItIUarWuMnbqZchlx/view).
+Further references include Perforce's
+[How to Write an SRS Document](https://www.perforce.com/blog/alm/how-write-software-requirements-specification-srs-document)
+and, for a higher level of detail on recommended guidelines for the SRS elements,
+[IEEE’s Recommended Practice for Software Requirements Specifications](https://drive.google.com/file/d/1G1vQq-RjnbEmTTzItIUarWuMnbqZchlx/view).
 
-_After completing the SRS, you’ll need to get it approved by key stakeholders. This will require everyone to review the latest version of the document_
+_After completing the SRS, you’ll need to get it approved by key stakeholders. This will require
+everyone to review the latest version of the document_
 
 ## Testing and Development
 
-Testing should be built into the software development process. Thoth-Tech advocates for a [Test Driven Development](#test-driven-development) (TDD) approach. In any event, all coding projects should consider and record their [Test Plan](#making-a-test-plan) and [Test Strategy](#test-strategy) and produce these as project deliverables.
+Testing should be built into the software development process. Thoth-Tech advocates for a
+[Test Driven Development](#test-driven-development) (TDD) approach. In any event, all coding
+projects should consider and record their [Test Plan](#making-a-test-plan) and
+[Test Strategy](#test-strategy) and produce these as project deliverables.
 
 ### Making a Test Plan
 
-For each product/feature, using the required specifications, flesh out the expected behaviour for different use case scenarios. A collaborative approach helps to make sure you are defining the right problem and solution; be sure to seek feedback from the team during this process. These scenarios will be detailed in a Test Plan, which will record each scenario to be tested, the expected outcome, and the actual outcome of tests. A simple Markdown [Test Plan Template](templates/test-plan-template.md) has been provided.
+For each product/feature, using the required specifications, flesh out the expected behaviour for
+different use case scenarios. A collaborative approach helps to make sure you are defining the right
+problem and solution; be sure to seek feedback from the team during this process. These scenarios
+will be detailed in a Test Plan, which will record each scenario to be tested, the expected outcome,
+and the actual outcome of tests. A simple Markdown
+[Test Plan Template](templates/test-plan-template.md) has been provided.
 
 ### Test Strategy
 
-You need to consider _how_ you are going to test your scenarios as part of this process – considering matters such as what [testing tools](#testing-tools) you will use, what platforms tests will be performed on, any release processes, and what deliverables will you need to produce. This should be considered as part of your Test Strategy – a deliverable which should be produced as part of the QA process. Other documents that may be produced as part of the QA process include a Test Plan and Bug Reports.
+You need to consider _how_ you are going to test your scenarios as part of this process –
+considering matters such as what [testing tools](#testing-tools) you will use, what platforms tests
+will be performed on, any release processes, and what deliverables will you need to produce. This
+should be considered as part of your Test Strategy – a deliverable which should be produced as part
+of the QA process. Other documents that may be produced as part of the QA process include a Test
+Plan and Bug Reports.
 
-Templates have been provided for sample [Test Strategy](templates/test-strategy-template.md), [Test Plan](templates/test-plan-template.md) and [Bug Report](templates/bug-report-template.md) documents.
+Templates have been provided for sample [Test Strategy](templates/test-strategy-template.md),
+[Test Plan](templates/test-plan-template.md) and [Bug Report](templates/bug-report-template.md)
+documents.
 
-While manual testing may be conducted initially, moving towards automated tests allows for better efficiency, ease of code checks and is the preferred method to allow automatic test incorporation into the deployment pipeline. Testing and processes, like many other in the Agile model, are not static, and can (and should) be improved on successive iterations. This may include iterating existing processes for testing releases as well as automating more functionality.
+While manual testing may be conducted initially, moving towards automated tests allows for better
+efficiency, ease of code checks and is the preferred method to allow automatic test incorporation
+into the deployment pipeline. Testing and processes, like many other in the Agile model, are not
+static, and can (and should) be improved on successive iterations. This may include iterating
+existing processes for testing releases as well as automating more functionality.
 
-Thoth-Tech encourages a [test driven development](#test-driven-development) approach, in which testing is intertwined with softward development. If your software coding has begun in advance of testing considerations, then you should still formulate a Testing Strategy, including a Test Plan, to verify that your code successfully meets requirements.
+Thoth-Tech encourages a [test driven development](#test-driven-development) approach, in which
+testing is intertwined with softward development. If your software coding has begun in advance of
+testing considerations, then you should still formulate a Testing Strategy, including a Test Plan,
+to verify that your code successfully meets requirements.
 
 ### Testing Tools
 
-Using testing tools makes tests easier to write and easier for future developers to understand. They add consistency and repeatability to the testing process, and make test design and documentation simpler.
+Using testing tools makes tests easier to write and easier for future developers to understand. They
+add consistency and repeatability to the testing process, and make test design and documentation
+simpler.
 
 Testing tools include:
 
@@ -165,15 +229,22 @@ Testing tools include:
 - [Catch2](https://github.com/catchorg/Catch2/tree/v2.x) (for C/C++)
 - Junit (for Java)
 - Nunit (for .Net languages, such as C#, F#, Visual Basic)
-- [Karma](https://karma-runner.github.io/latest/index.html) (a testing tool for automation that utilises other testing frameworks)
+- [Karma](https://karma-runner.github.io/latest/index.html) (a testing tool for automation that
+  utilises other testing frameworks)
 
-But there are many more. Look for what is currently available and popular in your language. Currently, proposals have been put forward for utilising [Jasmine](https://jasmine.github.io) and [Karma](https://karma-runner.github.io/latest/index.html) for relevant unit testing and automation and [Cypress](https://www.cypress.io/) for end-to-end testing in the OnTrack space.
+But there are many more. Look for what is currently available and popular in your language.
+Currently, proposals have been put forward for utilising [Jasmine](https://jasmine.github.io) and
+[Karma](https://karma-runner.github.io/latest/index.html) for relevant unit testing and automation
+and [Cypress](https://www.cypress.io/) for end-to-end testing in the OnTrack space.
 
 ## How do I prove my code does what it's supposed to do? <!-- omit in toc -->
 
 ## Test Driven Development
 
-By utilising _test driven development (TDD)_, software requirements are embedded into the testing and coding process, so that functionality is validated as it is coded. This assists to confirm code is actually fulfilling the requirements while improving the robustness of testing and paving the way for automation in deployment pipelines.
+By utilising _test driven development (TDD)_, software requirements are embedded into the testing
+and coding process, so that functionality is validated as it is coded. This assists to confirm code
+is actually fulfilling the requirements while improving the robustness of testing and paving the way
+for automation in deployment pipelines.
 
 How does it work?
 
@@ -184,23 +255,37 @@ How does it work?
 
 ### Determining appropriate tests
 
-Tests should come from your _requirements_ and _acceptance criteria_; they are designed to test requirements not methods.
+Tests should come from your _requirements_ and _acceptance criteria_; they are designed to test
+requirements not methods.
 
-From these, project teams solidify scenarios that relate to project requirements – make sure you collaborate and obtain feedback on these scenarios to check that you have understood the requirements correctly. This can be done through group brainstorming sessions (especially valuable in initial stages) and through returning to the team for feedback.
+From these, project teams solidify scenarios that relate to project requirements – make sure you
+collaborate and obtain feedback on these scenarios to check that you have understood the
+requirements correctly. This can be done through group brainstorming sessions (especially valuable
+in initial stages) and through returning to the team for feedback.
 
-Remember, test-driven development does lend itself to an iterative software development process, such as Agile, so it is quite suited to a development process where coders start with basic functionality that may be added to or improved in subsequent iterations. This is okay – you will progress and build, and using the TDD approach allows for evolving such code in a robust manner. A useful approach is to begin with base functionality and increase complexity.
+Remember, test-driven development does lend itself to an iterative software development process,
+such as Agile, so it is quite suited to a development process where coders start with basic
+functionality that may be added to or improved in subsequent iterations. This is okay – you will
+progress and build, and using the TDD approach allows for evolving such code in a robust manner. A
+useful approach is to begin with base functionality and increase complexity.
 
 ### Writing a failing test case
 
 _Why are we writing a test to fail?_
 
-Having determined our test case from our acceptance criteria, we begin by writing some code that will fail our test. Why? Because we want to make sure that our test works; we don't want later checks to be useless because we wrote our test incorrectly and are having false positives returned.
+Having determined our test case from our acceptance criteria, we begin by writing some code that
+will fail our test. Why? Because we want to make sure that our test works; we don't want later
+checks to be useless because we wrote our test incorrectly and are having false positives returned.
 
 ### Writing code to pass your test
 
-Once you've confirmed your test "works" by failing for code that doesn't pass your test, you can now write code to pass your test. This can also be an iterative process – first, starting with arbitrary values that you know will give the "expected" result (faking it to pass), before refining to be more broadly applicable to how your code needs to work in the live system.
+Once you've confirmed your test "works" by failing for code that doesn't pass your test, you can now
+write code to pass your test. This can also be an iterative process – first, starting with arbitrary
+values that you know will give the "expected" result (faking it to pass), before refining to be more
+broadly applicable to how your code needs to work in the live system.
 
-When you are satisfied that your code is complete, it is wise to challenge your test again with known failing code to reaffirm your testing is still functioning as expected.
+When you are satisfied that your code is complete, it is wise to challenge your test again with
+known failing code to reaffirm your testing is still functioning as expected.
 
 **What next?**
 
@@ -217,9 +302,11 @@ These are concerns which may be addressed through _code refactoring_.
 
 ### Refactoring Code
 
-Refactoring involves changing the _internal_ structure to make it more easily understood, effective and/or cheaper to modify without changing the _external behaviour_ of the code.
+Refactoring involves changing the _internal_ structure to make it more easily understood, effective
+and/or cheaper to modify without changing the _external behaviour_ of the code.
 
-While writing a failing test case and then coding it to pass focuses on **requirements** (and adding **new functionality** ), refactoring focuses on **improving design**.
+While writing a failing test case and then coding it to pass focuses on **requirements** (and adding
+**new functionality** ), refactoring focuses on **improving design**.
 
 **My code is complete and passing tests; is it time to refactor?**
 
@@ -233,17 +320,24 @@ these are good signs that it might be time to refactor.
 
 **How do I refactor?**
 
-Extract function refactoring is one common and intuitive approach to refactoring code: this involves comparing the code intention with the implementation. If the code is doing more than the intention, particularly if it is doing things that may be repeated elsewhere, it probably contains functions that should be split off.
+Extract function refactoring is one common and intuitive approach to refactoring code: this involves
+comparing the code intention with the implementation. If the code is doing more than the intention,
+particularly if it is doing things that may be repeated elsewhere, it probably contains functions
+that should be split off.
 
-[Refactoring.com](http://refactoring.com/) provides useful reading that covers a number of refactoring techniques.
+[Refactoring.com](http://refactoring.com/) provides useful reading that covers a number of
+refactoring techniques.
 
 **Further information about Test Driven Development**
 
 Deakin students have free access to LinkedIn Learning courses.
 
-A useful course on these general concepts is [Programming Foundations Test Driven Development](https://www.linkedin.com/learning/programming-foundations-test-driven-development-3)
+A useful course on these general concepts is
+[Programming Foundations Test Driven Development](https://www.linkedin.com/learning/programming-foundations-test-driven-development-3)
 
-Developers working with C++ may also find [Test Driven Development in C++](https://www.linkedin.com/learning/test-driven-development-in-c-plus-plus) useful
+Developers working with C++ may also find
+[Test Driven Development in C++](https://www.linkedin.com/learning/test-driven-development-in-c-plus-plus)
+useful
 
 ## Testing Templates
 

--- a/docs/products/dreambig/dreambig.md
+++ b/docs/products/dreambig/dreambig.md
@@ -1,21 +1,20 @@
 # DreamBig
 
-DreamBig is a new system innovation driven by the School of IT at Deakin. This
-will help students develop their professional identity across their course -
-helping better prepare them at graduation to smoothly enter the IT profession.​
+DreamBig is a new system innovation driven by the School of IT at Deakin. This will help students
+develop their professional identity across their course - helping better prepare them at graduation
+to smoothly enter the IT profession.​
 
 ## What are the goals for DreamBig?
 
-DreamBig is at its early inception and need a passionate team to shape its future.
-We would like to build a prototype and can help to achieve the following:
+DreamBig is at its early inception and need a passionate team to shape its future. We would like to
+build a prototype and can help to achieve the following:
 
 - Multi-dimensional visualisation of each student's growing professional identity
 - Used within curriculum to encourage engagement.
 - Scaffolds reflections on industry-readiness
-- Increases awareness of important milestones and dates for graduate recruitment
-  and internships
+- Increases awareness of important milestones and dates for graduate recruitment and internships
 - Customised paths for careers starters, career changers and career advancers.
 
-For the technical architecture, it would be suggested to lean on the established
-pattern set out by OnTrack project. However, this is subjected to change and the
-team is empowered to explore alternatives as they see fit.
+For the technical architecture, it would be suggested to lean on the established pattern set out by
+OnTrack project. However, this is subjected to change and the team is empowered to explore
+alternatives as they see fit.

--- a/docs/products/ontrack/ontrack.md
+++ b/docs/products/ontrack/ontrack.md
@@ -2,25 +2,29 @@
 
 ## What is OnTrack?
 
-OnTrack is a web assessment tool that provides students with a task oriented
-approach to portfolio assessment to stay aligned by completing tasks as part
-of their learning. More information can be found on the OnTrack [website](https://www.deakin.edu.au/students/help/about-clouddeakin/help-guides/assessment/ontrack).
+OnTrack is a web assessment tool that provides students with a task oriented approach to portfolio
+assessment to stay aligned by completing tasks as part of their learning. More information can be
+found on the OnTrack
+[website](https://www.deakin.edu.au/students/help/about-clouddeakin/help-guides/assessment/ontrack).
 
 ## What are the goals for OnTrack?
 
-The OnTrack group is to focus on the maintenance and development of Doubtfire. [Doubtfire](https://doubtfire.io/guides/overview) is a learning management system which is used at Deakin University by both students and staff. The group has been tasked with creating new features to enhance both the teaching experience for tutors and learning experience for students.
+The OnTrack group is to focus on the maintenance and development of Doubtfire.
+[Doubtfire](https://doubtfire.io/guides/overview) is a learning management system which is used at
+Deakin University by both students and staff. The group has been tasked with creating new features
+to enhance both the teaching experience for tutors and learning experience for students.
 
 ## Understanding OnTrack
 
 ### High level architecture
 
-![OnTrack Architecture](images/architecture.png)
-![OnTrack Dataflow](images/dataflow.png)
+![OnTrack Architecture](images/architecture.png) ![OnTrack Dataflow](images/dataflow.png)
 
 ### Getting Started
 
-Please follow the [installation instructions](https://doubtfire.io/guides#developer) for developers on the official
-product website.
+Please follow the [installation instructions](https://doubtfire.io/guides#developer) for developers
+on the official product website.
 
-For DoubtFire Web, if you are on Windows, it might be more convenient to set
-it up via Docker Desktop. Please follow the instructions laid out in this [doc](https://deakin365.sharepoint.com/:w:/r/sites/ThothTech2/Shared%20Documents/General/OnTrack%20Product/Useful%20Resources/Docker%20Auto%20Reload%20Instructions.docx?d=w46db2b73edfa41c8a1a18af8d07157be&csf=1&web=1&e=9DOKOr).
+For DoubtFire Web, if you are on Windows, it might be more convenient to set it up via Docker
+Desktop. Please follow the instructions laid out in this
+[doc](https://deakin365.sharepoint.com/:w:/r/sites/ThothTech2/Shared%20Documents/General/OnTrack%20Product/Useful%20Resources/Docker%20Auto%20Reload%20Instructions.docx?d=w46db2b73edfa41c8a1a18af8d07157be&csf=1&web=1&e=9DOKOr).

--- a/docs/products/ontrack/project-epics/documentation-epic.md
+++ b/docs/products/ontrack/project-epics/documentation-epic.md
@@ -2,11 +2,18 @@
 
 ## Background / Context
 
-The OnTrack project has been worked on for many years by external consultants who have not contributed efficiently and effectively. As a result of this, documentation containing the information about design decisions, requirements and user information is not accurate or up to date within our OnTrack product.
+The OnTrack project has been worked on for many years by external consultants who have not
+contributed efficiently and effectively. As a result of this, documentation containing the
+information about design decisions, requirements and user information is not accurate or up to date
+within our OnTrack product.
 
 ## Business Value
 
-To ensure that all work is usable,and the decision-making process is visible for future stakeholders, the business would like to retrospectively analyse any gaps in the documentation of our products and produce documentation. This will ensure previous decisions, design, and requirements are easily accessible to all future users, developers, and other stakeholders so relevant context is provided for all work in the future.
+To ensure that all work is usable,and the decision-making process is visible for future
+stakeholders, the business would like to retrospectively analyse any gaps in the documentation of
+our products and produce documentation. This will ensure previous decisions, design, and
+requirements are easily accessible to all future users, developers, and other stakeholders so
+relevant context is provided for all work in the future.
 
 ## In Scope
 
@@ -22,10 +29,13 @@ To ensure that all work is usable,and the decision-making process is visible for
 
 ## What needs to happen
 
-The Ontrack repo needs to be analysed for relevant documentation that needs to be updated, improved, or created if none exists already.
+The Ontrack repo needs to be analysed for relevant documentation that needs to be updated, improved,
+or created if none exists already.
 
-- A report should be produced on what has been found from this analysis with the proposed solutions for prioritisation.
-- A report of recommendations and expectations for current project teams to implement for documentation of their projects.
+- A report should be produced on what has been found from this analysis with the proposed solutions
+  for prioritisation.
+- A report of recommendations and expectations for current project teams to implement for
+  documentation of their projects.
 
 ## Assumptions / Dependencies
 

--- a/docs/products/splashkit/splashkit.md
+++ b/docs/products/splashkit/splashkit.md
@@ -4,25 +4,38 @@
 
 The SplashKit website is accessible here: [SplashKit - Home](https://SplashKit.io/)
 
-SplashKit is an open-source Software Development Kit (SDK) created with the purpose of reducing the overhead required for truly technical coding.
+SplashKit is an open-source Software Development Kit (SDK) created with the purpose of reducing the
+overhead required for truly technical coding.
 
-SplashKit includes a large library of methods that a user may experiment with and apply. A function is a piece of code that accomplishes a purpose by calling other lines of code, it's much simpler to use pre-defined functions rather than creating all the code yourself when creating a game.
+SplashKit includes a large library of methods that a user may experiment with and apply. A function
+is a piece of code that accomplishes a purpose by calling other lines of code, it's much simpler to
+use pre-defined functions rather than creating all the code yourself when creating a game.
 
-Although SplashKit is a large library, capabilities may always be improved or added to expand its realism and complexity. This enables users to include more sophisticated elements into their SplashKit projects more easily and quickly.
+Although SplashKit is a large library, capabilities may always be improved or added to expand its
+realism and complexity. This enables users to include more sophisticated elements into their
+SplashKit projects more easily and quickly.
 
 ### Where is it used?
 
-Currently, SplashKit is primarily used within Deakin University, with the intention of growing into a larger Educational Toolkit.
+Currently, SplashKit is primarily used within Deakin University, with the intention of growing into
+a larger Educational Toolkit.
 
-The students at Deakin University, studying Introduction to Programming have been the most exposed to this product. They are the ideal consumers of this product – within the first 12 weeks of using SplashKit in Introduction to Programming, students can code 2D games with unrestricted creativity and have a grounded knowledge of C++.
+The students at Deakin University, studying Introduction to Programming have been the most exposed
+to this product. They are the ideal consumers of this product – within the first 12 weeks of using
+SplashKit in Introduction to Programming, students can code 2D games with unrestricted creativity
+and have a grounded knowledge of C++.
 
 ### What does this mean for Thoth Tech?
 
-Here at Thoth Tech, our aim is to improve both functionality, experience and support for upon the current library of the SplashKit SDK. Allowing users to create more realistic gameplay and games. We also wish to build a solution capable of highlighting the achievements of the SplashKit users to ensure exposure of the product and capability as an educational tool.
+Here at Thoth Tech, our aim is to improve both functionality, experience and support for upon the
+current library of the SplashKit SDK. Allowing users to create more realistic gameplay and games. We
+also wish to build a solution capable of highlighting the achievements of the SplashKit users to
+ensure exposure of the product and capability as an educational tool.
 
 ## What are the goals for SplashKit?
 
-This is entirely up to the team’s expertise, interest, and vision. However, the direction previously discussed includes:
+This is entirely up to the team’s expertise, interest, and vision. However, the direction previously
+discussed includes:
 
 - Fix incompatibility of SplashKit with Python version 3.8.x
 - Building upon the menu framework
@@ -40,7 +53,8 @@ The following steps will provide the reader with a basic understanding of Splash
 
 1. Become familiar with SplashKit
 
-   - Visit the SplashKit.io website - here you can read documentation and articles about the SplashKit functions.
+   - Visit the SplashKit.io website - here you can read documentation and articles about the
+     SplashKit functions.
    - Explore the SplashKit Source Code.
    - Read through the User Guides created by previous developers in the Background Docs Folder.
 
@@ -84,9 +98,11 @@ SplashKit requires some software to set up:
 - Visual Studio Code
 - G++ language tools
 
-As SplashKit is aimed at beginners, Visual Studio Code is the optimal choice due to its simplicity and ease of use.
+As SplashKit is aimed at beginners, Visual Studio Code is the optimal choice due to its simplicity
+and ease of use.
 
-A written installation guide for all Operating Systems (OS) can be found [here](https://splashkit.io/articles/installation/)
+A written installation guide for all Operating Systems (OS) can be found
+[here](https://splashkit.io/articles/installation/)
 
 A video installation guide for Windows OS can be found
 [here](https://deakin365.sharepoint.com/:v:/s/ThothTech2/EXWvjZKY61RGjgewzgySCS0BXQVagohU70wRH3hh2cl_0g?e=tgMpiP)
@@ -102,13 +118,18 @@ SplashKit comprises of 4 sections:
 - SplashKit.io
 - SplashKit translator
 
-**SplashKit Manager** or SKM is the CLI/App tool for installing and managing SplashKit, as well as creating, building, and running SplashKit projects. SKM is highly editable through including folders and bash code into the SplashKit directory / GitHub.
+**SplashKit Manager** or SKM is the CLI/App tool for installing and managing SplashKit, as well as
+creating, building, and running SplashKit projects. SKM is highly editable through including folders
+and bash code into the SplashKit directory / GitHub.
 
-**SplashKit Core** is the code for SplashKit, it is what makes up the all-purpose SDK. All direction to SplashKit comprised of creating or building upon the core code. Each component was referred to as a module.
+**SplashKit Core** is the code for SplashKit, it is what makes up the all-purpose SDK. All direction
+to SplashKit comprised of creating or building upon the core code. Each component was referred to as
+a module.
 
 **SplashKit.io** is the website, which is referred to throughout this document.
 
-**SplashKit translator** is responsible for the translation of the SplashKit C++ source into another language.
+**SplashKit translator** is responsible for the translation of the SplashKit C++ source into another
+language.
 
 ### SplashKit on your device
 
@@ -118,13 +139,16 @@ SplashKit duplicates a version of the Source Code onto your device. This is acce
 C:\msys64\home\<user>\.SplashKit
 ```
 
-This is how SplashKit Manager (SKM) can create projects with preconfigured files. For C++ projects, these can be accessed here:
+This is how SplashKit Manager (SKM) can create projects with preconfigured files. For C++ projects,
+these can be accessed here:
 
 ```shell
 C:\msys64\home\<user>\.SplashKit\new\c++\files
 ```
 
-SplashKit is a library which includes a variety of functionality detailed on the website. Each file is referred to as a module, which groups the functions by use. The function code and headers of SplashKit can be accessed here:
+SplashKit is a library which includes a variety of functionality detailed on the website. Each file
+is referred to as a module, which groups the functions by use. The function code and headers of
+SplashKit can be accessed here:
 
 ```shell
 C:\msys64\home\<user>\.SplashKit\source

--- a/docs/projects/t1-2022/teams.md
+++ b/docs/projects/t1-2022/teams.md
@@ -22,7 +22,8 @@ Product Lead: Jordan Trainor
 
 ### Front-end Migration
 
-- Teams Channel: [Front End Migration](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Front%20End%20Migration?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:40cc53f7f52d42cd8d15bddad593aa01@thread.tacv2&ctx=channel)
+- Teams Channel:
+  [Front End Migration](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Front%20End%20Migration?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:40cc53f7f52d42cd8d15bddad593aa01@thread.tacv2&ctx=channel)
 - Trello Board: [Front-end Migration](https://trello.com/b/pFPgCaIo/front-end-migration)
 - Delivery Lead: David Kwiatkowski, Jesse Hancock
 - Team Member (pair):
@@ -37,7 +38,8 @@ Product Lead: Jordan Trainor
 
 ### Deployment
 
-- Teams Channel: [Deployment](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Deployment?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:42df0a88caed442a867bc8c41c25416d@thread.tacv2&ctx=channel)
+- Teams Channel:
+  [Deployment](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Deployment?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:42df0a88caed442a867bc8c41c25416d@thread.tacv2&ctx=channel)
 - Trello Board: [Deployment](https://trello.com/b/dI1yx9A1/deployment)
 - Delivery Lead: Jordan Trainor (Interim)
 
@@ -55,24 +57,28 @@ Product Lead: Jordan Trainor
 
 ### Jupyter Notebook Support
 
-- Teams Channel: [Jupyter Notebook Support Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/General?threadId=19:TfS2kJmJ0HXihVO4_9pXuxrzAN_4em5uQgIvQByzhWQ1@thread.tacv2&ctx=channel)
+- Teams Channel:
+  [Jupyter Notebook Support Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/General?threadId=19:TfS2kJmJ0HXihVO4_9pXuxrzAN_4em5uQgIvQByzhWQ1@thread.tacv2&ctx=channel)
 - Trello Board: [Jupyter Support](https://trello.com/b/3lWJEuDQ/jupyter-sypport)
 - Delivery Lead: Ethan Keirs
 - Team Member: Jordan Litsas, Matt Clark, Lachlan Foy, Chetan Nagar
 
 ### Voice Verification
 
-- Teams Channel: [Voice Verification - OnTrack](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Voice%20Verification%20-%20OnTrack?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:ea448ec4e26449a5b74e0d6dc9be71f4@thread.tacv2&ctx=channel)
+- Teams Channel:
+  [Voice Verification - OnTrack](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Voice%20Verification%20-%20OnTrack?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:ea448ec4e26449a5b74e0d6dc9be71f4@thread.tacv2&ctx=channel)
 - Trello Board: [Voice Verification](https://trello.com/b/lkRdh1Fp/voice-verification)
 - Delivery Lead: Shaine Christmas
 - Team Member: Devin Jayasinghe, Yanjun Chen, Gao Yujun, Ha Nguyen, Daniel Le
 
 ### Documentation
 
-- Teams Channel: [OnTrack Documentation](https://teams.microsoft.com/l/channel/19%3arhz4yutH2rF0sJU-xbcqAIS-tZ59n3j2c5LMzqDdicA1%40thread.tacv2/General?groupId=215e9f4e-95e6-4a1a-84b7-489f22d4ecae&tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6)
+- Teams Channel:
+  [OnTrack Documentation](https://teams.microsoft.com/l/channel/19%3arhz4yutH2rF0sJU-xbcqAIS-tZ59n3j2c5LMzqDdicA1%40thread.tacv2/General?groupId=215e9f4e-95e6-4a1a-84b7-489f22d4ecae&tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6)
 - Trello Board: [Documentation](https://trello.com/b/FHz8evJG/documentation)
 - Delivery Lead: James Micallef
-- Team Member: Parth Aneja, Manisha Jyoti, Md Fahim Mizi, Shivam Singh, Kosta Constantinou, Faiq Rehman
+- Team Member: Parth Aneja, Manisha Jyoti, Md Fahim Mizi, Shivam Singh, Kosta Constantinou, Faiq
+  Rehman
 
 ## DreamBig
 
@@ -80,14 +86,17 @@ Product Lead: Abigail Howe
 
 ### DreamBig Prototype
 
-- Teams Channel: [DreamBig Prototype Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/DreamBig%20Prototype%20Team?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:71cf013320fb430db1e7427d9d7d61ad@thread.tacv2&ctx=channel)
+- Teams Channel:
+  [DreamBig Prototype Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/DreamBig%20Prototype%20Team?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:71cf013320fb430db1e7427d9d7d61ad@thread.tacv2&ctx=channel)
 - Trello Board: [DreamBig](https://trello.com/b/5hGRqxJO/dreambig)
 - Delivery Lead: Neha Makineni
-- Team Member: Li Harry, Chen Guanyu, Munatsi Matipano, Zac Brydon, Harrison Allwood, Lei Feng, George Gkoumas
+- Team Member: Li Harry, Chen Guanyu, Munatsi Matipano, Zac Brydon, Harrison Allwood, Lei Feng,
+  George Gkoumas
 
 ### Internal Systems
 
-- Teams Channel: [Internal Systems](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Internal%20Systems?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:8778e877fdca4e899c42d52b1b1ead32@thread.tacv2&ctx=channel)
+- Teams Channel:
+  [Internal Systems](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Internal%20Systems?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:8778e877fdca4e899c42d52b1b1ead32@thread.tacv2&ctx=channel)
 - Trello Board: [Internal Systems](https://trello.com/b/Y3chllnR/internal-systems)
 - Delivery Lead: Matthew Fletcher
 - Team Member: Areeb Jjaz, Tushar, Manveen Bhullar
@@ -98,13 +107,16 @@ Product Lead: Yash Kondlekar
 
 ### Operations
 
-- Teams Channel: [SplashKit Operations Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/SplashKit%20Operations%20Team?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:845469c493864784b3de109e2da8060b@thread.tacv2&ctx=channel)
-- Trello Board: [Distribution Channels - Operations](https://trello.com/b/uDYt4NJB/distribution-channels-operations)
+- Teams Channel:
+  [SplashKit Operations Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/SplashKit%20Operations%20Team?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:845469c493864784b3de109e2da8060b@thread.tacv2&ctx=channel)
+- Trello Board:
+  [Distribution Channels - Operations](https://trello.com/b/uDYt4NJB/distribution-channels-operations)
 - Delivery Lead: Aiden Molluso
 
 #### Migrate Arcana to SplashKit
 
-- Trello Board: [Migrate Arcana to SplashKit - Operations](https://trello.com/b/23WxTlXO/migrate-arcana-to-splashkit-operations)
+- Trello Board:
+  [Migrate Arcana to SplashKit - Operations](https://trello.com/b/23WxTlXO/migrate-arcana-to-splashkit-operations)
 - Team Member: Devesh Juggiah, Ray Guo
 
 #### Distribution Channels
@@ -113,7 +125,8 @@ Product Lead: Yash Kondlekar
 
 ### Extensions
 
-- Teams Channel: [Language Extensions](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Language%20Extensions?threadId=19:b7feb53773244946936db2ee9df315f4@thread.tacv2&ctx=channel)
+- Teams Channel:
+  [Language Extensions](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Language%20Extensions?threadId=19:b7feb53773244946936db2ee9df315f4@thread.tacv2&ctx=channel)
 - Trello Board: [Language Extensions](https://trello.com/b/xIVeBYwU/language-extensions)
 - Delivery Lead: Allan Farrell
 
@@ -127,7 +140,8 @@ Product Lead: Yash Kondlekar
 
 ### Applications
 
-- Teams Channel: [Applications Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Applications%20Team?threadId=19:1a52251788de42edbda8153f1913bd90@thread.tacv2&ctx=channel)
+- Teams Channel:
+  [Applications Team](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/Applications%20Team?threadId=19:1a52251788de42edbda8153f1913bd90@thread.tacv2&ctx=channel)
 - Trello Board: [Arcade Team](https://trello.com/b/cnMs1BW6/arcade-team)
 - Delivery Lead: Nick Agiazis
 
@@ -141,7 +155,8 @@ Product Lead: Yash Kondlekar
 
 ### Modules
 
-- Teams Channel: [SplashKit Modules](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/SplashKit%20Modules?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:3abb0a52353b436db927e16d3c152903@thread.tacv2&ctx=channel)
+- Teams Channel:
+  [SplashKit Modules](https://teams.microsoft.com/_?tenantId=d02378ec-1688-46d5-8540-1c28b5f470f6#/school/conversations/SplashKit%20Modules?groupId=0e15669c-3f66-49aa-b023-640fe1dda2e0&threadId=19:3abb0a52353b436db927e16d3c152903@thread.tacv2&ctx=channel)
 - Trello Board: [Modules](https://trello.com/b/SKqf30oS/modules)
 - Delivery Lead: Alex Hocking
 

--- a/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week2.md
+++ b/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week2.md
@@ -2,15 +2,43 @@
 
 Good evening General! It's your friendly neighbourhood leadership team here.
 
-An update: You should have started to have been contacted by your project team delivery leads, possibly been added to a channel and by now you all should be joined to your relevant Trello boards with an **onboarding card completed.**
+An update: You should have started to have been contacted by your project team delivery leads,
+possibly been added to a channel and by now you all should be joined to your relevant Trello boards
+with an **onboarding card completed.**
 
-**Task 1.1 is due on Sunday.** The information from our company meeting which is accessible in this channel - including the presentation, along with the information you gain from your team meeting and resources available in your Trello workspace, the Thoth Tech repo, and the Ontrack & Splashkit old files, it should be enough for you to complete this task. If you have been through all these resources and still are not sure - your first point of contact is your Delivery lead (please be patient with them too, they are onboarding and getting started just like everyone else.) If you have not heard from them by Friday - please reach out to one of the other leadership team named in all company meeting powerpoint.
+**Task 1.1 is due on Sunday.** The information from our company meeting which is accessible in this
+channel - including the presentation, along with the information you gain from your team meeting and
+resources available in your Trello workspace, the Thoth Tech repo, and the Ontrack & Splashkit old
+files, it should be enough for you to complete this task. If you have been through all these
+resources and still are not sure - your first point of contact is your Delivery lead (please be
+patient with them too, they are onboarding and getting started just like everyone else.) If you have
+not heard from them by Friday - please reach out to one of the other leadership team named in all
+company meeting powerpoint.
 
-**Task 2.1 is now due next Sunday 27th March.** We understand you all are keen to get started on things but as we mentioned in the all company meeting, this is a transition trimester and leadership is working very hard behind the scenes to ensure you are all set up for success. Please be patient with us. We are aiming to be transparent and communicate relevant updates as soon as they are available. At this point in time, the first part of Task 2.1 will be completed by the leadership team, and the second part will have a section that is to be completed by your project team next week.
-This means that your focus this week is to get set up, connect with your team, discuss how you will communicate and work together and what your team cadence will be, discuss your skills and your availability so you can find the best way to work with each other and most importantly make sure you are aligned with each other. Whatever you decide your position title is, I challenge you all to pick an area alignment to drive in your team (docs, QA, data, tech) that will help challenge you to think about your projects differently. This is something that will make you more valuable to hire in the real world.
+**Task 2.1 is now due next Sunday 27th March.** We understand you all are keen to get started on
+things but as we mentioned in the all company meeting, this is a transition trimester and leadership
+is working very hard behind the scenes to ensure you are all set up for success. Please be patient
+with us. We are aiming to be transparent and communicate relevant updates as soon as they are
+available. At this point in time, the first part of Task 2.1 will be completed by the leadership
+team, and the second part will have a section that is to be completed by your project team next
+week. This means that your focus this week is to get set up, connect with your team, discuss how you
+will communicate and work together and what your team cadence will be, discuss your skills and your
+availability so you can find the best way to work with each other and most importantly make sure you
+are aligned with each other. Whatever you decide your position title is, I challenge you all to pick
+an area alignment to drive in your team (docs, QA, data, tech) that will help challenge you to think
+about your projects differently. This is something that will make you more valuable to hire in the
+real world.
 
-**Next week** will be about really digging into the requirements of your project, scoping the tasks, how will you will ensure your work is robust, how will you make sure your work is documented, starting to up-skill, asking questions, learning about Github, coding hygiene and quality assurance processes etc.
+**Next week** will be about really digging into the requirements of your project, scoping the tasks,
+how will you will ensure your work is robust, how will you make sure your work is documented,
+starting to up-skill, asking questions, learning about Github, coding hygiene and quality assurance
+processes etc.
 
-**Lastly, I know this unit can be overwhelming.** There are a lot of new concepts, tools and terms you may have never used or heard of before. Please don't be afraid to ask questions. We may not always have the answer straight away, but we are here to support you all and will find a solution. Currently we are working on some content to help support those who may have never used Github on this scale before - hopefully to be released sometime on the weekend. If there are other things you think could be useful, let us know and we can work on getting out some resources or learning out.
+**Lastly, I know this unit can be overwhelming.** There are a lot of new concepts, tools and terms
+you may have never used or heard of before. Please don't be afraid to ask questions. We may not
+always have the answer straight away, but we are here to support you all and will find a solution.
+Currently we are working on some content to help support those who may have never used Github on
+this scale before - hopefully to be released sometime on the weekend. If there are other things you
+think could be useful, let us know and we can work on getting out some resources or learning out.
 
 Thank you all for coming to our TedTalk.

--- a/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week3.md
+++ b/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week3.md
@@ -4,15 +4,37 @@ Good Evening Thoth Tech
 
 Here is your update from your friendly neighbourhood leadership team for the week.
 
-This week is going to be about deep diving into your projects. Your delivery leads will be receiving a **project epic** which will give you all the information your team needs to start understanding, discovering, scoping and planning for your projects. This epic will allow you to start creating tasks and will give you all the information you will need for Task 2.1.
-**Task 2.1** which is a Company Report is due this coming Sunday. This document will be the same for every person in the company.
-The first half of the report will be filled out by the leadership team. This includes the following sections (Table of Contents, Leadership Team, Trimester Goals & Objectives, Company Structure)
+This week is going to be about deep diving into your projects. Your delivery leads will be receiving
+a **project epic** which will give you all the information your team needs to start understanding,
+discovering, scoping and planning for your projects. This epic will allow you to start creating
+tasks and will give you all the information you will need for Task 2.1. **Task 2.1** which is a
+Company Report is due this coming Sunday. This document will be the same for every person in the
+company. The first half of the report will be filled out by the leadership team. This includes the
+following sections (Table of Contents, Leadership Team, Trimester Goals & Objectives, Company
+Structure)
 
-The second part is a breakdown of the projects. Each project team will work on this part together and submit to the leadership team to compile into a document. Your delivery leads will be taking note of anyone who is contributing to this. **The deadline for your team to submit your project section is Saturday.** This allows us time to compile the document for feedback from the entire company on Sunday. The deadlines for feedback on full document will be Sunday 4pm. **After this, only one Junior and one Senior will need to submit this for it to be submitted for the entire company. Leadership will assign a senior and junior to do this. You do not all need to submit it individually.**
+The second part is a breakdown of the projects. Each project team will work on this part together
+and submit to the leadership team to compile into a document. Your delivery leads will be taking
+note of anyone who is contributing to this. **The deadline for your team to submit your project
+section is Saturday.** This allows us time to compile the document for feedback from the entire
+company on Sunday. The deadlines for feedback on full document will be Sunday 4pm. **After this,
+only one Junior and one Senior will need to submit this for it to be submitted for the entire
+company. Leadership will assign a senior and junior to do this. You do not all need to submit it
+individually.**
 
-Please note, most of you won’t be starting on your development work this week, potentially not even next week. One of our goals is to emulate what real world work is like and how companies run. In the real world, a lot of planning and consideration is completed before actual development occurs. How will we test? How will we document? How will we capture data? Are there legal/regulatory considerations? This is crucial to our success, and is an important skill for you all to be learning.
-Leadership is looking at running a **Github/Repo QandA** learning session sometime this week for those who may not have experience with repos of this scale and might be feeling a bit overwhelmed. If this is something you would like to happen, please let us know in the comments.
+Please note, most of you won’t be starting on your development work this week, potentially not even
+next week. One of our goals is to emulate what real world work is like and how companies run. In the
+real world, a lot of planning and consideration is completed before actual development occurs. How
+will we test? How will we document? How will we capture data? Are there legal/regulatory
+considerations? This is crucial to our success, and is an important skill for you all to be
+learning. Leadership is looking at running a **Github/Repo QandA** learning session sometime this
+week for those who may not have experience with repos of this scale and might be feeling a bit
+overwhelmed. If this is something you would like to happen, please let us know in the comments.
 
-Lastly, evidence for portfolios is crucial. Your delivery leads will chat to you about this more in your meetings this week but by now you should already have some evidence from your team’s worklog, skills & availability matrix, onboarding card from your Trello board, meeting recordings, meeting minutes, and screenshots from you engaging in your channel. It is everyone’s responsibility in your team to make sure you all have evidence, not just your delivery leads.
+Lastly, evidence for portfolios is crucial. Your delivery leads will chat to you about this more in
+your meetings this week but by now you should already have some evidence from your team’s worklog,
+skills & availability matrix, onboarding card from your Trello board, meeting recordings, meeting
+minutes, and screenshots from you engaging in your channel. It is everyone’s responsibility in your
+team to make sure you all have evidence, not just your delivery leads.
 
 Thank you for coming to our TedTalk.

--- a/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week4.md
+++ b/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week4.md
@@ -4,18 +4,29 @@ Good Evening Thoth Tech
 
 Here is this week's update from your friendly neighbourhood leadership team.
 
-You should be starting to feel more comfortable with **GitHub this week** – if not please watch the Github workshop session; it’s valuable to review if you are new to all things git!
+You should be starting to feel more comfortable with **GitHub this week** – if not please watch the
+Github workshop session; it’s valuable to review if you are new to all things git!
 
-Your team **Trello board** should be continuing to fill out. This week there should be a focus on task assignment, analysis of existing repos to understand the full scope of work, upskilling requirements, research and planning.
+Your team **Trello board** should be continuing to fill out. This week there should be a focus on
+task assignment, analysis of existing repos to understand the full scope of work, upskilling
+requirements, research and planning.
 
-Start to think about your **individual retrospectives**; what evidence do you have so far? What do you want to learn more of? Are there any areas you think you need to work on?
+Start to think about your **individual retrospectives**; what evidence do you have so far? What do
+you want to learn more of? Are there any areas you think you need to work on?
 
-**D/HD aiming students** should also be thinking about and working on their 5.1 task. If you feel like you may not be meeting the standard or want to get a better understanding, talk to leadership about how we can give you more responsibility/opportunities/help you understand. Note there are 4 tasks due on the same day for HD students.
+**D/HD aiming students** should also be thinking about and working on their 5.1 task. If you feel
+like you may not be meeting the standard or want to get a better understanding, talk to leadership
+about how we can give you more responsibility/opportunities/help you understand. Note there are 4
+tasks due on the same day for HD students.
 
 There are also upcoming opportunities for D/HD students in the pipeline – watch this space!
 
-All **OnTrack tasks** now have task sheets and resources where applicable. Note that any tasks that start with “Company” are group, company-wide submissions; the rest are individual. All employees by now should have **reviewed the rubric** to ensure they understand what they need to do for their desired grade. If you want to chat about requirements – reach out.
+All **OnTrack tasks** now have task sheets and resources where applicable. Note that any tasks that
+start with “Company” are group, company-wide submissions; the rest are individual. All employees by
+now should have **reviewed the rubric** to ensure they understand what they need to do for their
+desired grade. If you want to chat about requirements – reach out.
 
-We will also be releasing a **Quality Assurance** document this week with **guidelines on branching and commit etiquette.**
+We will also be releasing a **Quality Assurance** document this week with **guidelines on branching
+and commit etiquette.**
 
 Thank you for all your continuing work, and have a great week!

--- a/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week5.md
+++ b/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week5.md
@@ -4,8 +4,8 @@ Good Evening Thoth Tech.
 
 Here is this week's update from your friendly neighbourhood leadership team.
 
-First and foremost, congratulations on the excellent feedback on Task 2.1! It
-was a team effort and everyone deserves a pat on the back.
+First and foremost, congratulations on the excellent feedback on Task 2.1! It was a team effort and
+everyone deserves a pat on the back.
 
 ## OnTrack tasks
 
@@ -15,60 +15,57 @@ If you need some guidance, please watch the D/HD workshop
 [video](https://deakin365.sharepoint.com/:v:/r/sites/ThothTech2/Shared%20Documents/General/Recordings/2-4-22%20D-HD%20Workshop.mp4?csf=1&web=1&e=0Tomse).
 It is beneficial for everyone.
 
-Please also spend some time looking at Task 6.x. For D/HD aiming students, there
-are 4 tasks that due on the same day on Sun 24/04/2022. Preparation is crucial
-so we don't scramble close to the due day.
+Please also spend some time looking at Task 6.x. For D/HD aiming students, there are 4 tasks that
+due on the same day on Sun 24/04/2022. Preparation is crucial so we don't scramble close to the due
+day.
 
 ## Company tasks
 
 - Please fill in the learning
   [survey](https://forms.office.com/Pages/ResponsePage.aspx?id=7Hgj0IgW1UaFQBwotfRw9pxmFQ5mP6pJsCNkD-HdouBUNUVBVlBEMlVTT0RKWkdVNTJOT0o5MTNMTSQlQCN0PWcu)
-  to help us understand the company learning and development needs and plan for
-  resources.
+  to help us understand the company learning and development needs and plan for resources.
 - Please review the Quality Assurance (QA)
   [document](https://github.com/thoth-tech/handbook/blob/main/docs/processes/quality-assurance/quality-assurance-overview.md)
-  and start a conversation around the topic with your team. There will be a
-  session on this during the week (Wed 6/04/2022 6:00 PM - 6:45 PM) and it is
-  open to everyone.
+  and start a conversation around the topic with your team. There will be a session on this during
+  the week (Wed 6/04/2022 6:00 PM - 6:45 PM) and it is open to everyone.
 - Please review the Communication
-  [Guide](https://github.com/thoth-tech/handbook/blob/main/docs/communication/communication.md)
-  and see if it can help to streamline your team communication process.
+  [Guide](https://github.com/thoth-tech/handbook/blob/main/docs/communication/communication.md) and
+  see if it can help to streamline your team communication process.
 - Any seniors who want to mentor, please reach out to the Leadership team.
-- Any juniors who would like to work towards leadership next trimester, we are
-  organising an Expression of Interest for attending the leadership conference.
-  Please stay tuned for more information.
+- Any juniors who would like to work towards leadership next trimester, we are organising an
+  Expression of Interest for attending the leadership conference. Please stay tuned for more
+  information.
 - Please work on the relevant project repositories from the
-  [thoth-tech organisation](https://github.com/thoth-tech) on GitHub. Please do
-  not pull or push to the original Doubtfire or SplashKit repositories.
+  [thoth-tech organisation](https://github.com/thoth-tech) on GitHub. Please do not pull or push to
+  the original Doubtfire or SplashKit repositories.
 
 ## What you can expect
 
-- Showcase for D/HD students is being organised at the end of the week. We would
-  like to present project Trello boards, plans, testing & data strategies to the
-  Managing Directors. It would be a great opportunity to receive feedback.
-  Please speak to your Delivery Leads to confirm as soon as possible.
+- Showcase for D/HD students is being organised at the end of the week. We would like to present
+  project Trello boards, plans, testing & data strategies to the Managing Directors. It would be a
+  great opportunity to receive feedback. Please speak to your Delivery Leads to confirm as soon as
+  possible.
 - We are transitioning away from MS Word to the Thoth-tech
-  [handbook](https://github.com/thoth-tech/handbook) repository on GitHub
-  starting from this week onward.
-- We are planning for more training in the next weeks so please watch out for
-  invites in your mailbox or subscribe to the
+  [handbook](https://github.com/thoth-tech/handbook) repository on GitHub starting from this week
+  onward.
+- We are planning for more training in the next weeks so please watch out for invites in your
+  mailbox or subscribe to the
   [shared calendar](https://outlook.office.com/calendar/group/deakin365.onmicrosoft.com/_thoth-tech/view/month).
 
 ## What we can expect
 
-- We expect that Trello boards should be planned out and upskilling should
-  already be happening. If you need help, please reach out
-- Team members should feel comfortable with GitHub and creating pull requests.
-  Please review the training
+- We expect that Trello boards should be planned out and upskilling should already be happening. If
+  you need help, please reach out
+- Team members should feel comfortable with GitHub and creating pull requests. Please review the
+  training
   [video](https://deakin365.sharepoint.com/:v:/r/sites/ThothTech2/Shared%20Documents/General/Recordings/24-3-22%20Github%20Repos%20QnA.mp4?csf=1&web=1&e=Pa3Hh0)
   and the QA
   [document](https://github.com/thoth-tech/handbook/blob/main/docs/processes/quality-assurance/quality-assurance-overview.md)
-  if you are still unsure. If you have done both of these things and still feel
-  lost, please reach out to the Area Leads.
-- While there is a focus on students having responsibility for sourcing their
-  work in Capstone, if a student finds themselves with nothing to do and is
-  unsure, they should, at a minimum, speak to their team leader to ask "what can
-  I do?". Even if you are only looking for a pass grade, it is up to you to make
-  sure you have work to demonstrate requirements.
+  if you are still unsure. If you have done both of these things and still feel lost, please reach
+  out to the Area Leads.
+- While there is a focus on students having responsibility for sourcing their work in Capstone, if a
+  student finds themselves with nothing to do and is unsure, they should, at a minimum, speak to
+  their team leader to ask "what can I do?". Even if you are only looking for a pass grade, it is up
+  to you to make sure you have work to demonstrate requirements.
 
 Thank you for all your continuing work, and have a great week!

--- a/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week6.md
+++ b/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week6.md
@@ -6,31 +6,41 @@ Good Morning Thoth Tech
 
 Here is this week's update from your friendly neighbourhood leadership team.
 
-Firstly, congratulations on being half way through Capstone, you should all be very proud of your efforts (I hope you know we are). This also means its time to dive right into your projects.
+Firstly, congratulations on being half way through Capstone, you should all be very proud of your
+efforts (I hope you know we are). This also means its time to dive right into your projects.
 
 ## OnTrack tasks
 
 Please start working on Task 6.x.
 
-For Task 6.2, this is an update of the company report and project submissions to be added by the 21st to allow time to compile- more information will be coming but:
+For Task 6.2, this is an update of the company report and project submissions to be added by the
+21st to allow time to compile- more information will be coming but:
 
-This will be worked on collaboratively on GitHub by submitting .md PRs to team folder in branch: task6.2/company-report-project-updates
+This will be worked on collaboratively on GitHub by submitting .md PRs to team folder in branch:
+task6.2/company-report-project-updates
 
-This will include discussion on testing and data strategies and Software Requirement Specification documents, along with a project update
+This will include discussion on testing and data strategies and Software Requirement Specification
+documents, along with a project update
 
-For D/HD aiming students, there are 4 tasks that due on the same day on Sun 24/04/2022 - please be aware of this and plan accordingly
+For D/HD aiming students, there are 4 tasks that due on the same day on Sun 24/04/2022 - please be
+aware of this and plan accordingly
 
 ## Company tasks
 
 If you are interested in Leadership, check out the Leadership Conference. The sign up form is here
 
-We know there are still some students who might have questions and don't feel comfortable asking, so we have made a Q&A form and questions will be answered all at once in a FAQ style post.
+We know there are still some students who might have questions and don't feel comfortable asking, so
+we have made a Q&A form and questions will be answered all at once in a FAQ style post.
 
-Please work on the relevant project repositories from the thoth-tech organisation on GitHub. Please do not pull or push to the original Doubtfire or SplashKit repositories - if you have the wrong repo, check out this guide
+Please work on the relevant project repositories from the thoth-tech organisation on GitHub. Please
+do not pull or push to the original Doubtfire or SplashKit repositories - if you have the wrong
+repo, check out this guide
 
-There will also be a Company wide meeting after Intra-Trimester Break (so be looking out for this). More information will come soon.
+There will also be a Company wide meeting after Intra-Trimester Break (so be looking out for this).
+More information will come soon.
 
-You should have seen the new Documentation Repo. If you have any questions, first person to reach out to is Documentation and they can answer your questions.
+You should have seen the new Documentation Repo. If you have any questions, first person to reach
+out to is Documentation and they can answer your questions.
 
 If the file is relevant companywide and for more than one trimester, it goes in the handbook repo
 
@@ -38,9 +48,11 @@ If the file is relevant to a product or project, it goes in the documentation re
 
 ## What you can expect
 
-Area Leads will be jumping into project meetings this week to catch up on the progress and answer any questions.
+Area Leads will be jumping into project meetings this week to catch up on the progress and answer
+any questions.
 
-From this point on the Area Leads will be taking a step back, first point of call for information is the Products Leads - they are eager to help out.
+From this point on the Area Leads will be taking a step back, first point of call for information is
+the Products Leads - they are eager to help out.
 
 ## What we can expect
 
@@ -48,7 +60,8 @@ By now you should have:
 
 - Received project epics
 - Broken it down into user stories
-- Trello boards filled out in depth with clear communication on what is happening - reviews were given last week
+- Trello boards filled out in depth with clear communication on what is happening - reviews were
+  given last week
 - Software requirements Specification (SRS)
 - Discussed data requirements
 - Discussed testing requirements
@@ -63,5 +76,5 @@ We will expect the teams are working on:
 - Beginning work on projects if all up to date (this will be different for all teams)
 - Continuing your leadership/cohort contributions (D/HD students)
 
-Thank you for all your continuing work. If you have any questions, please reach out to the Delivery and Product leads first. For more serious enquires the Area Leads.
-Have a great week!
+Thank you for all your continuing work. If you have any questions, please reach out to the Delivery
+and Product leads first. For more serious enquires the Area Leads. Have a great week!

--- a/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week8.md
+++ b/docs/projects/t1-2022/thoth-tech-leadership/weekly-announcements/week8.md
@@ -6,14 +6,36 @@ It’s your friendly neighbourhood leadership team here.
 
 ## RECAP:
 
-- Thank you to the 31 responses in the Onboarding feedback form. This will be invaluable information for next trimester. We are happy to report a 4/5 stars for on-boarding, hopefully next tri it will reach a 5/5 experience.
-- By now you should have all reviewed the all company meeting where we reviewed what we have achieved so far, what we still need to achieve and what new resources have become available since the beginning of trimester.
+- Thank you to the 31 responses in the Onboarding feedback form. This will be invaluable information
+  for next trimester. We are happy to report a 4/5 stars for on-boarding, hopefully next tri it will
+  reach a 5/5 experience.
+- By now you should have all reviewed the all company meeting where we reviewed what we have
+  achieved so far, what we still need to achieve and what new resources have become available since
+  the beginning of trimester.
 
 ## TO DO:
 
-- As we approach the end of the trimester, we are moving into Delivery and Documentation mode. If you are lost or need help - PLEASE REACH OUT. We can’t support you if you don’t let us know you need help.
-- As you should now be aware from the company meeting, there is a new documentation repo. Please begin putting your research and development notes into the corresponding folder. This is expected to be completed in time for handover (Week 11) and will require you to create PRs in .md format. If you start now you will have no issues. Remember to add people from your project and docs team to review the Pull Request.
-- We would love some input regarding your project key results and the data required to validate that. Please see the Project metrics template for some guidance. The key results are not only restricted to the product. They can encompass delivery and people. For example, successfully up-skill 100% of team members on TypeScript, etc.
-- T2 2022 questionnaire: JUNIORS please fill this out to assist with ensuring you are placed appropriately next year and get a chance to take on roles and growth opportunities of interest. This is your chance to have your say.
-- Test strategy: has your team completed yours? This is an important part of the Quality Assurance process and should exist before you start coding. Reminder, a sample Test Strategy template is in the handbook. If you have particular testing resources and skills, there will be opportunities to express interest this week to help out your fellow Thoth-Tech company members.
-- Remember to book into your calendars, next Monday 9th of May, Daniel from Midnyte City is presenting a guest session all around Experience working in Industry. It’s at 12-1pm so you can dial in over lunchtime. Daniel has real world delivery lead experience, so this is a great opportunity to gain valuable insight into the real world and enhance your capstone leadership learnings and will be a good cohort contribution for your OnTrack Tasks.
+- As we approach the end of the trimester, we are moving into Delivery and Documentation mode. If
+  you are lost or need help - PLEASE REACH OUT. We can’t support you if you don’t let us know you
+  need help.
+- As you should now be aware from the company meeting, there is a new documentation repo. Please
+  begin putting your research and development notes into the corresponding folder. This is expected
+  to be completed in time for handover (Week 11) and will require you to create PRs in .md format.
+  If you start now you will have no issues. Remember to add people from your project and docs team
+  to review the Pull Request.
+- We would love some input regarding your project key results and the data required to validate
+  that. Please see the Project metrics template for some guidance. The key results are not only
+  restricted to the product. They can encompass delivery and people. For example, successfully
+  up-skill 100% of team members on TypeScript, etc.
+- T2 2022 questionnaire: JUNIORS please fill this out to assist with ensuring you are placed
+  appropriately next year and get a chance to take on roles and growth opportunities of interest.
+  This is your chance to have your say.
+- Test strategy: has your team completed yours? This is an important part of the Quality Assurance
+  process and should exist before you start coding. Reminder, a sample Test Strategy template is in
+  the handbook. If you have particular testing resources and skills, there will be opportunities to
+  express interest this week to help out your fellow Thoth-Tech company members.
+- Remember to book into your calendars, next Monday 9th of May, Daniel from Midnyte City is
+  presenting a guest session all around Experience working in Industry. It’s at 12-1pm so you can
+  dial in over lunchtime. Daniel has real world delivery lead experience, so this is a great
+  opportunity to gain valuable insight into the real world and enhance your capstone leadership
+  learnings and will be a good cohort contribution for your OnTrack Tasks.

--- a/docs/projects/t1-2022/thoth-tech-leadership/weekly-todos/week5.md
+++ b/docs/projects/t1-2022/thoth-tech-leadership/weekly-todos/week5.md
@@ -2,78 +2,69 @@
 
 ## The story so far
 
-By now your entire team should have done a team retrospective. Meetings are hard
-so please try to think of ways to collaborate async with your team members. For
-example, use Miro to collect ideas async and shorten meetings with clear agenda.
+By now your entire team should have done a team retrospective. Meetings are hard so please try to
+think of ways to collaborate async with your team members. For example, use Miro to collect ideas
+async and shorten meetings with clear agenda.
 
-Please continue to promote your members efforts using the 'Shoutout!' channel or
-team meetings. It helps to drive engagement and improve team morale.
+Please continue to promote your members efforts using the 'Shoutout!' channel or team meetings. It
+helps to drive engagement and improve team morale.
 
 ## Planning
 
-Please organise time for presentation and preparing the materials for the
-Showcase this week. **This is not compulsory - just an opportunity for students
-aiming for higher marks** to showcase your team's work to the managing
-directors. You need to ensure your team are aware of this, and communicate to us
-who is interested and what time so we can schedule it, however you do not need
-to participate if you do not want to.
+Please organise time for presentation and preparing the materials for the Showcase this week. **This
+is not compulsory - just an opportunity for students aiming for higher marks** to showcase your
+team's work to the managing directors. You need to ensure your team are aware of this, and
+communicate to us who is interested and what time so we can schedule it, however you do not need to
+participate if you do not want to.
 
-Remind team to start looking at the Software Requirements Specification in
-preparation for OnTrack Task 6.2.
+Remind team to start looking at the Software Requirements Specification in preparation for OnTrack
+Task 6.2.
 
-Continue to build out your Trello boards. For teams who are still struggling
-with this, we have prepared a Trello
-[guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/trello-guide.md).
-We will run a short workshop later this week to cover in more detail. We will
-also be starting to provide some specific feedback on your Trello boards this
-week.
+Continue to build out your Trello boards. For teams who are still struggling with this, we have
+prepared a Trello
+[guide](https://github.com/thoth-tech/handbook/blob/main/docs/learning/training/trello-guide.md). We
+will run a short workshop later this week to cover in more detail. We will also be starting to
+provide some specific feedback on your Trello boards this week.
 
-If you are would like to improve sprint planning, the upcoming delivery lead
-workshop might be of great interest. We have rescheduled it from 6 - 7PM on
-Tuesday 05/04/2022.
+If you are would like to improve sprint planning, the upcoming delivery lead workshop might be of
+great interest. We have rescheduled it from 6 - 7PM on Tuesday 05/04/2022.
 
-Guidance on user stories and requirement extracting will also be coming later
-this week.
+Guidance on user stories and requirement extracting will also be coming later this week.
 
 ## Calendar
 
 Please ensure your team's regular meetings are in the
 [Thoth Tech calendar](https://outlook.office.com/calendar/group/deakin365.onmicrosoft.com/_thoth-tech/view/month).
-This provides visibility and also means that leadership know when your meetings
-are incase we need to jump in to support. If you have any difficulties with
-this, let us know.
+This provides visibility and also means that leadership know when your meetings are incase we need
+to jump in to support. If you have any difficulties with this, let us know.
 
 ## Leadership support (you):
 
-You could help the company to help us understand the company learning and
-development needs and plan for resources. Please advocate the
+You could help the company to help us understand the company learning and development needs and plan
+for resources. Please advocate the
 [survey](https://forms.office.com/Pages/ResponsePage.aspx?id=7Hgj0IgW1UaFQBwotfRw9pxmFQ5mP6pJsCNkD-HdouBUNUVBVlBEMlVTT0RKWkdVNTJOT0o5MTNMTSQlQCN0PWcu)
-to your team. If any team members would like to facilitate any training or you
-have identified any experts that can spread knowledge beyond your teams, please
-do not hesitate to reach out to the Area Leads. We love to collaborate and build
-a great learning culture at Thoth-tech.
+to your team. If any team members would like to facilitate any training or you have identified any
+experts that can spread knowledge beyond your teams, please do not hesitate to reach out to the Area
+Leads. We love to collaborate and build a great learning culture at Thoth-tech.
 
-If you would like to express interest to attend the leadership conference -
-please let us know. This is a shadowing development experience that would be
-beneficial, particularly for juniors taking more leadership responsibility next
-trimester.
+If you would like to express interest to attend the leadership conference - please let us know. This
+is a shadowing development experience that would be beneficial, particularly for juniors taking more
+leadership responsibility next trimester.
 
 Please familiarise yourself with the following guidelines:
 
 - The
   [Quality Assurance strategy](https://github.com/thoth-tech/handbook/blob/main/docs/processes/quality-assurance/quality-assurance-overview.md)
-  and think how it applies to the context of your project. We are running a Q&A
-  session between 6:00 PM - 6:45 PM on Wed 6/04/2022 and love to hear your
-  feedback and questions.
+  and think how it applies to the context of your project. We are running a Q&A session between 6:00
+  PM - 6:45 PM on Wed 6/04/2022 and love to hear your feedback and questions.
 
 - The Communication
-  [Guide](https://github.com/thoth-tech/handbook/blob/main/docs/communication/communication.md)
-  and see if it can help to streamline your team communication process. It's a
-  living document and we'd absolutely love your contribution to improve it.
+  [Guide](https://github.com/thoth-tech/handbook/blob/main/docs/communication/communication.md) and
+  see if it can help to streamline your team communication process. It's a living document and we'd
+  absolutely love your contribution to improve it.
 
 ## Team support:
 
-Please keep monitor your team health and the level of engagement. We recommend a
-good 7-min read on the topic of
-[Conscious Leadership](https://blog.alexmaccaw.com/conscious-leadership/) that
-you might find useful.
+Please keep monitor your team health and the level of engagement. We recommend a good 7-min read on
+the topic of [Conscious Leadership](https://blog.alexmaccaw.com/conscious-leadership/) that you
+might find useful.


### PR DESCRIPTION
# Description

This standardizes the Prettier rules to be the same as the [those](https://github.com/thoth-tech/documentation/blob/main/.prettierrc) in the `documentation` repository.

I have also run `npm format` to enforce the wrapping rules to all markdown files (apology for the big changeset 🙏🏼).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code