### PR TITLE
fix: broken list format and typo fixes on workshop

### DIFF
--- a/docs/learning/training/distinction-high-distinction-workshop.md
+++ b/docs/learning/training/distinction-high-distinction-workshop.md
@@ -54,7 +54,7 @@ Show you are a responsible team member to receive a credit.
 
 At this level you will be building the pieces needed by your team to complete the puzzle. You work
 at this level if you are a responsible team member. You can follow instructions from your lead and
-deliver the designated work at an acceptable standard in the allocated timeframe. You must show:
+deliver the designated work at an acceptable standard in the allocated timeframe. You must:
 
 - Show clear contributions
 - Be engaged and present

--- a/docs/learning/training/distinction-high-distinction-workshop.md
+++ b/docs/learning/training/distinction-high-distinction-workshop.md
@@ -45,8 +45,8 @@ team's work.
 
 At this level, you will assist in building the pieces needed by your team to complete the puzzle. It
 would help if you had support to complete your work to an acceptable standard or get the tasks done
-on time. Luckily, you have a team that will provide you with that support; make sure you don't let
-them down.
+on time. Luckily, you have a team that will provide you with that support; make sure you are doing
+them proud.
 
 ### Credit
 

--- a/docs/learning/training/distinction-high-distinction-workshop.md
+++ b/docs/learning/training/distinction-high-distinction-workshop.md
@@ -1,5 +1,41 @@
 # D/HD Workshop Discussion Points
 
+## Talking Points
+
+- The idea of this Capstone is to run like an actual company to give as close to real world as
+  possible
+- Do not wait to be told what to do, find things to do - show initiative
+- Not just what you do, but how you communicate it
+  - Evidence
+  - Engagement
+  - Retrospective
+- Make sure you regularly read the rubric and self-identify opportunities
+- Make sure you are familiar with your Course Learning Outcomes (CLO)
+- Reach out to your delivery lead, product lead or area leads if you want feedback on ideas or have
+  questions
+- Supporting your delivery leads – ask if they would like to delegate you something?
+- How are you supporting your project members? Are they confident? How are you supporting the wider
+  company team?
+- What skills do you have? What are you confident in? - support your team, consult with other
+  project groups
+
+## Contributions
+
+- Invest in other people’s development
+- Hype team contributions in retrospectives - what you have done but also supporting other team
+  members
+- Feedback conversations - shout out channel - not just for leadership to use
+- Identify opportunities and pioneer something
+- Handbook contributions
+- Documentation - moving everything towards Git
+- Get creative
+- Run a workshop? Make a how-to video? Post about an ‘aha’ moment, share resources, start a
+  committee? Connect with people in other companies doing similar things
+- Cohort contributions - are you engaging? Sharing things that you have learnt? What do you want to
+  work towards?
+- Do you want to be a leader next trimester? How are you trying to achieve that? Who do you need to
+  communicate with?
+
 ## Grade Level overview
 
 ### Pass
@@ -9,19 +45,20 @@ team's work.
 
 At this level, you will assist in building the pieces needed by your team to complete the puzzle. It
 would help if you had support to complete your work to an acceptable standard or get the tasks done
-on time.
+on time. Luckily, you have a team that will provide you with that support; make sure you don't let
+them down.
 
 ### Credit
 
 Show you are a responsible team member to receive a credit.
 
-At this leve you will be buliding the pieces needed by your team to complete the puzzle. You work at
-this level if you are a responsible team member. You can follow instructions from your lead and
+At this level you will be building the pieces needed by your team to complete the puzzle. You work
+at this level if you are a responsible team member. You can follow instructions from your lead and
 deliver the designated work at an acceptable standard in the allocated timeframe. You must show:
 
-- Clear contributions to your project
-- Be engaged and Present
-- Responsibility
+- Clear contributions
+- Be engaged and present
+- Responsible
 
 ### Distinction
 
@@ -29,7 +66,7 @@ Showcase your leadership in the team and a cohort for distinction.
 
 At this level you will be building a puzzle. Your team members will build the pieces needed but you
 need to provide adequate guidance and support to make sure the pieces are those needed. You work at
-this level if you can demonstrate leaderhsip within you team and support the vision of the company
+this level if you can demonstrate leadership within you team and support the vision of the company
 directors. You must show:
 
 - Credit+ contributions
@@ -40,34 +77,11 @@ directors. You must show:
 
 Showcase excellent and outstanding achievements for high distinction.
 
-At this level you need to demonstrate how you have shown excellence in what you have achieved in the
-capstone program. You want to demonstrate how your leadership helped shape the company, and your
-cohort interactions helped develop students across the program. YOu will be able to articulate the
+At this level, you need to demonstrate how you have shown excellence in what you have achieved in
+the capstone program. You want to demonstrate how your leadership helped shape the company, and your
+cohort interactions helped develop students across the program. You will be able to articulate the
 aspects of your performance that demonstrate excellence in leading people, technical expertise,
 communication skills, quality of work and/or level of achievement. You must show:
 
 - Distinction+ contributions
 - Excellence
-
-## Talking Points:
-
-⁃ The idea of this capstone is to run like an actual company to give as close to real world as
-possible ⁃ Do not wait to be told what to do, find things to do - show initiative ⁃ Not just what
-you do, but how you communicate it; evidence, engagement, retrospective ⁃ Make sure you regularly
-read the rubric and self-identify opportunities ⁃ Make sure you are familiar with your Course
-Learning Outcomes ⁃ Reach out to your delivery lead, product lead or area leads if you want feedback
-on ideas or have questions ⁃ Supporting your delivery leads – ask if they would like to delegate you
-something? ⁃ How are you supporting your project members? Are they confident? How are you supporting
-the wider company team? ⁃ What skills do you have? What are you confident in? - support your team,
-consult with other project groups
-
-## Contributions:
-
-⁃ Invest in other people’s development - hype team contributions in retrospectives – what you have
-done but also supporting other team members ⁃ Feedback conversations - shout out channel - not just
-for leadership to use ⁃ Identify opportunities and pioneer something ⁃ Handbook contributions ⁃
-Documentation - moving everything towards git ⁃ Get creative ⁃ Run a workshop? Make a how to video?
-Post about an ‘aha’ moment, share resources, start a committee? Connect with people in other
-companies doing similar things ⁃ Cohort contributions - are you engaging? Sharing things that you
-have learnt? ⁃ What do you want to work towards? Do you want to be a leader next trimester? How are
-you trying to achieve that? Who do you need to communicate with?

--- a/docs/learning/training/distinction-high-distinction-workshop.md
+++ b/docs/learning/training/distinction-high-distinction-workshop.md
@@ -56,9 +56,9 @@ At this level you will be building the pieces needed by your team to complete th
 at this level if you are a responsible team member. You can follow instructions from your lead and
 deliver the designated work at an acceptable standard in the allocated timeframe. You must show:
 
-- Clear contributions
+- Show clear contributions
 - Be engaged and present
-- Responsible
+- Be responsible
 
 ### Distinction
 

--- a/docs/learning/training/index.md
+++ b/docs/learning/training/index.md
@@ -5,8 +5,6 @@ technical development.
 
 A list of training can be seen below:
 
-## Training
-
 - Installing npm
 - Product Epics
 - User Stories

--- a/docs/learning/training/index.md
+++ b/docs/learning/training/index.md
@@ -5,13 +5,11 @@ technical development.
 
 A list of training can be seen below:
 
-- Installing npm
-- Product Epics
-- User Stories
 - [Changing Fork Location](changing-git-fork-location.md)
 - [Configuring Jenkins](configuring-jenkins.md)
 - [Developing with WSL2](developing-with-wsl2.md)
 - [Distinction/High Distinction Workshop](distinction-high-distinction-workshop.md)
+- [Epics and User Stories](../../processes/quality-assurance/testing-and-dev.md#epics-and-user-stories)
 - [Markdown Guide](markdown-guide.md)
 - [Trello Guide](trello-guide.md)
 - [Writing Documentation](writing-documentation.md)


### PR DESCRIPTION
# Description

- Fix broken list format on D/HD Workshop doc
- Fix some small typos
- Re-order sections according to the original [doc](https://deakin365.sharepoint.com/:w:/r/sites/ThothTech2-Leadership/_layouts/15/Doc.aspx?sourcedoc=%7B8E4ED901-DC53-4771-A4C7-8780CEFA89FA%7D&file=D%20HD%20Workshop%20Notes.docx&action=default&mobileredirect=true)

## Type of change

- [x] Documentation (update or new)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
